### PR TITLE
Improve errors

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,5 +1,5 @@
 from argparse import ArgumentParser
-from runner import run_job
+from runner import run_cohort_extractor
 from runner import watch
 
 
@@ -21,7 +21,7 @@ if __name__ == "__main__":
     )
     options = parser.parse_args()
     if options.subparser_name == "run":
-        run_job({"repo": options.repo, "tag": options.tag})
+        run_cohort_extractor({"repo": options.repo, "tag": options.tag})
     elif options.subparser_name == "watch":
         watch(options.queue_endpoint)
     else:

--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -185,7 +185,7 @@ def fetch_study_source(workdir, job):
 def report_result(future):
     job = future.job
     joblogger = get_job_logger(job)
-    id_message = f"Error id {job_id_from_job(job)}"
+    id_message = f"id {job_id_from_job(job)}"
     try:
         job = future.result(
             timeout=COHORT_EXTRACTOR_TIMEOUT

--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -214,7 +214,7 @@ def report_result(future):
             job["url"],
             json={
                 "status_code": error.status_code,
-                "status_message": f"{repr(error)} {id_message}",
+                "status_message": f"{error.safe_details()} {id_message}",
             },
             auth=get_auth(),
         )

--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -109,6 +109,10 @@ def run_cohort_extractor(job):
         # By setting the name to the volume_name, we are guaranteeing only
         # one identical job can run at once
         container_name = re.sub(r"[^a-zA-Z0-9]", "-", volume_name)
+        # Regex from
+        # https://github.com/moby/moby/blob/be97c66708c24727836a22247319ff2943d91a03/daemon/names/names.go#L5-L6
+        if not re.match(r"[a-zA-Z0-9][a-zA-Z0-9_.-]", container_name):
+            raise BadDockerImageName(f"Bad image name `{container_name}`")
         cmd = [
             "docker",
             "run",

--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -137,7 +137,6 @@ def run_cohort_extractor(job):
             joblogger.info("cohort-extractor subdocker stdout: %s", result.stdout)
         else:
             raise CohortExtractorError(result.stderr)
-        result.check_returncode()
         job["output_url"] = str(output_path)
         return job
 

--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -1,25 +1,53 @@
-from pathlib import Path
-from urllib.parse import urlparse
-from pebble import ProcessPool
 from concurrent.futures import TimeoutError
+from pathlib import Path
+from pebble import ProcessPool
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
+from urllib.parse import urlparse
 import logging
 import os
 import re
 import requests
 import subprocess
-import sys
 import tempfile
 import time
 
 from tinynetrc import Netrc
 
+from runner.exceptions import BadDockerImageName
+from runner.exceptions import CohortExtractorError
+from runner.exceptions import GitCloneError
+from runner.exceptions import InvalidRepo
+from runner.exceptions import OpenSafelyError
+from runner.exceptions import RepoNotFound
 
 HOUR = 60 * 60
 POLL_INTERVAL = 1
+COHORT_EXTRACTOR_TIMEOUT = 24 * HOUR
 
-logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+# Create a logger with a field for recording a unique job id, and a
+# `baselogger` adapter which fills this field with a hyphen, for use
+# when logging events not associated with jobs
+FORMAT = "%(asctime)-15s %(levelname)-10s  %(job_id)-10s %(message)s"
+logger = logging.getLogger(__name__)
+handler = logging.StreamHandler()
+formatter = logging.Formatter(FORMAT)
+handler.setFormatter(formatter)
+logger.setLevel(logging.INFO)
+logger.addHandler(handler)
+baselogger = logging.LoggerAdapter(logger, {"job_id": "-"})
+
+
+def job_id_from_job(job):
+    """An opaque string for use in logging to help trace events related to
+    a specific job
+    """
+    return "job#" + re.match(r".*/([0-9]+)/?$", job["url"]).groups()[0]
+
+
+def get_job_logger(job):
+    job_id = job_id_from_job(job)
+    return logging.LoggerAdapter(logger, {"job_id": job_id})
 
 
 def validate_input_files(workdir):
@@ -31,7 +59,7 @@ def validate_input_files(workdir):
         if not (workdir / required).exists():
             missing.append(required)
     if missing:
-        raise RuntimeError(
+        raise InvalidRepo(
             f"Folders {', '.join(missing)} must exist; is this an OpenSAFELY repo?"
         )
     for path in workdir.rglob("*"):
@@ -47,107 +75,164 @@ def validate_input_files(workdir):
         if mimetype not in ["text", "inode"] and not result.startswith(
             "application/pdf"
         ):
-            raise RuntimeError(
+            raise InvalidRepo(
                 f"All analysis input files must be text, found {result} at {path}"
             )
-    logging.info(f"Repo at {workdir} successfully validated")
 
 
-def run_cohort_extractor(database_url, workdir, volume_name):
-    # If running this within a docker container, the storage base
-    # should be a volume mounted from the docker host
-    storage_base = Path(os.environ["OPENSAFELY_RUNNER_STORAGE_BASE"])
-    # We create `output_path` and then map it straight through to the
-    # inner docker container, so that docker-within-docker can write
-    # straight through to the (optionally-mounted) storage base
-    output_path = storage_base / volume_name
-    output_path.mkdir(parents=True, exist_ok=True)
-    # By setting the name to the volume_name, we are guaranteeing only
-    # one identical job can run at once
-    container_name = re.sub(r"[^a-zA-Z0-9]", "-", volume_name)
-    cmd = [
-        "docker",
-        "run",
-        "--name",
-        container_name,
-        "--rm",
-        "--log-driver",
-        "none",
-        "-a",
-        "stdout",
-        "-a",
-        "stderr",
-        "--volume",
-        f"{output_path}:{output_path}",
-        "--volume",
-        f"{workdir}/analysis:/workspace/analysis",
-        "--volume",
-        f"{workdir}/codelists:/workspace/codelists",
-        "docker.pkg.github.com/opensafely/cohort-extractor/cohort-extractor:latest",
-        "generate_cohort",
-        f"--database-url={database_url}",
-        f"--output-dir={output_path}",
-    ]
+def run_cohort_extractor(job):
+    joblogger = get_job_logger(job)
+    joblogger.info(f"Starting job")
+    repo = job["repo"]
+    tag = job["tag"]
+    db = job["db"]
+    set_auth()
+    database_url = os.environ[f"{db.upper()}_DATABASE_URL"]
+    with tempfile.TemporaryDirectory(
+        dir=os.environ["OPENSAFELY_RUNNER_STORAGE_BASE"]
+    ) as tmpdir:
+        os.chdir(tmpdir)
+        volume_name = make_volume_name(repo, tag, db)
+        workdir = os.path.join(tmpdir, volume_name)
+        fetch_study_source(workdir, job)
+        validate_input_files(workdir)
+        joblogger.info(f"Repo at {workdir} successfully validated")
 
-    os.chdir(workdir)
-    logging.info(f"Running subdocker cmd `{' '.join(cmd)}`")
-    result = subprocess.run(cmd, capture_output=True, encoding="utf8")
-    if result.returncode == 0:
-        log = logging.info
-    else:
-        log = logging.error
-    log(f"cohort-extractor subdocker stdout: {result.stdout}")
-    log(f"cohort-extractor subdocker stderr: {result.stderr}")
-    result.check_returncode()
-    return output_path
+        # If running this within a docker container, the storage base
+        # should be a volume mounted from the docker host
+        storage_base = Path(os.environ["OPENSAFELY_RUNNER_STORAGE_BASE"])
+        # We create `output_path` and then map it straight through to the
+        # inner docker container, so that docker-within-docker can write
+        # straight through to the (optionally-mounted) storage base
+        output_path = storage_base / volume_name
+        output_path.mkdir(parents=True, exist_ok=True)
+        # By setting the name to the volume_name, we are guaranteeing only
+        # one identical job can run at once
+        container_name = re.sub(r"[^a-zA-Z0-9]", "-", volume_name)
+        cmd = [
+            "docker",
+            "run",
+            "--name",
+            container_name,
+            "--rm",
+            "--log-driver",
+            "none",
+            "-a",
+            "stdout",
+            "-a",
+            "stderr",
+            "--volume",
+            f"{output_path}:{output_path}",
+            "--volume",
+            f"{workdir}/analysis:/workspace/analysis",
+            "--volume",
+            f"{workdir}/codelists:/workspace/codelists",
+            "docker.pkg.github.com/opensafely/cohort-extractor/cohort-extractor:latest",
+            "generate_cohort",
+            f"--database-url={database_url}",
+            f"--output-dir={output_path}",
+        ]
+
+        os.chdir(workdir)
+        joblogger.info("Running subdocker cmd `%s` in %s", cmd, workdir)
+        result = subprocess.run(cmd, capture_output=True, encoding="utf8")
+        if result.returncode == 0:
+            joblogger.info("cohort-extractor subdocker stdout: %s", result.stdout)
+        else:
+            raise CohortExtractorError(result.stderr)
+        result.check_returncode()
+        job["output_url"] = str(output_path)
+        return job
 
 
 def make_volume_name(repo, branch_or_tag, db_flavour):
-    repo_name = urlparse(repo).path[1:].split("/")[-1]
+    repo_name = urlparse(repo).path[1:]
+    if repo_name.endswith("/"):
+        repo_name = repo_name[:-1]
+    repo_name = repo_name.split("/")[-1]
     return repo_name + "-" + branch_or_tag + "-" + db_flavour
 
 
-def fetch_study_source(
-    repo, branch_or_tag, workdir,
-):
+def fetch_study_source(workdir, job):
     """Checkout source over Github API to a temporary location.
     """
+    repo = job["repo"]
+    branch_or_tag = job["tag"]
     max_retries = 3
+    joblogger = get_job_logger(job)
     for attempt in range(max_retries + 1):
         cmd = ["git", "clone", "--depth", "1", "--branch", branch_or_tag, repo, workdir]
-        msg = f"Running `{' '.join(cmd)}`"
-        if attempt > 0:
-            msg += f" (attempt #{attempt})"
-        logging.info(msg)
+        joblogger.info("Running %s, attempt %s", cmd, attempt)
         try:
             subprocess.check_output(cmd, stderr=subprocess.STDOUT, encoding="utf8")
             break
         except subprocess.CalledProcessError as e:
-            if "Repository not found" in e.output:
-                raise
+            if "not found" in e.output:
+                raise RepoNotFound(e.output)
             elif attempt < max_retries:
-                logging.warning(f"Failed `{' '.join(cmd)}`; sleeping, then retrying")
+                joblogger.warning("Failed clone; sleeping, then retrying")
                 time.sleep(10)
             else:
-                raise
+                raise GitCloneError(cmd) from e
 
 
 def report_result(future):
     job = future.job
+    joblogger = get_job_logger(job)
+    id_message = f"Error id {job_id_from_job(job)}"
     try:
-        job = future.result()  # blocks until results are ready
+        job = future.result(
+            timeout=COHORT_EXTRACTOR_TIMEOUT
+        )  # blocks until results are ready
         requests.patch(
             job["url"],
             json={"status_code": 0, "output_url": job["output_url"]},
             auth=get_auth(),
         )
-        logging.info(f"Reported success for job {job}")
+        joblogger.info("Reported success to job server")
     except TimeoutError as error:
-        requests.patch(job["url"], json={"status_code": -1}, auth=get_auth())
-        logging.exception(error)
+        requests.patch(
+            job["url"],
+            json={
+                "status_code": -1,
+                "status_message": f"TimeoutError({COHORT_EXTRACTOR_TIMEOUT}s) {id_message}",
+            },
+            auth=get_auth(),
+        )
+        joblogger.info("Reported error -1 (timeout) to job server")
+        # Remove pebble's RemoteTraceback exception from reporting
+        error.__cause__ = None
+        joblogger.exception(error)
+    except OpenSafelyError as error:
+        requests.patch(
+            job["url"],
+            json={
+                "status_code": error.status_code,
+                "status_message": f"{repr(error)} {id_message}",
+            },
+            auth=get_auth(),
+        )
+        joblogger.info(
+            "Reported error %s (%s) to job server",
+            error.status_code,
+            f"{repr(error)} {id_message}",
+        )
+        # Remove pebble's RemoteTraceback exception from reporting
+        error.__cause__ = None
+        joblogger.exception(error)
     except Exception as error:
-        requests.patch(job["url"], json={"status_code": 1}, auth=get_auth())
-        logging.exception(error)
+        requests.patch(
+            job["url"],
+            json={
+                "status_code": 99,
+                "status_message": "Unclassified error {id_message}",
+            },
+            auth=get_auth(),
+        )
+        joblogger.info("Reported error 99 (unclassified) to job server")
+        # Don't remove remotetraceback, because we haven't considered
+        # handling it explicitly, and the context could help
+        joblogger.exception(error)
 
 
 def set_auth():
@@ -172,33 +257,12 @@ def set_auth():
     return (login, password)
 
 
-def run_job(job):
-    repo = job["repo"]
-    tag = job["tag"]
-    db = job["db"]
-    set_auth()
-    database_url = os.environ[f"{db.upper()}_DATABASE_URL"]
-    logging.info(f"Starting job {job}")
-    with tempfile.TemporaryDirectory(
-        dir=os.environ["OPENSAFELY_RUNNER_STORAGE_BASE"]
-    ) as tmpdir:
-        os.chdir(tmpdir)
-        volume_name = make_volume_name(repo, tag, db)
-        workdir = os.path.join(tmpdir, volume_name)
-        fetch_study_source(repo, tag, workdir)
-        validate_input_files(workdir)
-        job["output_url"] = str(
-            run_cohort_extractor(database_url, workdir, volume_name)
-        )
-        return job
-
-
 def get_auth():
     return (os.environ["QUEUE_USER"], os.environ["QUEUE_PASS"])
 
 
 def watch(queue_endpoint, loop=True):
-    logging.info(f"Started watching {queue_endpoint}")
+    baselogger.info(f"Started watching {queue_endpoint}")
     session = requests.Session()
     # Retries for up to 2 minutes, by default
     retry = Retry(connect=30, backoff_factor=0.5)
@@ -206,7 +270,7 @@ def watch(queue_endpoint, loop=True):
     session.mount(queue_endpoint, adapter)
     with ProcessPool(max_tasks=50) as pool:
         while True:
-            logging.debug(f"Polling {queue_endpoint}")
+            baselogger.debug(f"Polling {queue_endpoint}")
             try:
                 result = session.get(
                     queue_endpoint,
@@ -218,7 +282,7 @@ def watch(queue_endpoint, loop=True):
                     auth=get_auth(),
                 )
             except requests.exceptions.ConnectionError:
-                logging.exception("Connection error; sleeping for 15 mins")
+                baselogger.exception("Connection error; sleeping for 15 mins")
                 time.sleep(60 * 15)
             result.raise_for_status()
             jobs = result.json()
@@ -230,7 +294,7 @@ def watch(queue_endpoint, loop=True):
                     job["url"], json={"started": True}, auth=get_auth()
                 )
                 response.raise_for_status()
-                future = pool.schedule(run_job, (job,), timeout=6 * HOUR,)
+                future = pool.schedule(run_cohort_extractor, (job,), timeout=6 * HOUR,)
                 future.job = job
                 future.add_done_callback(report_result)
             if loop:

--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -63,7 +63,8 @@ def validate_input_files(workdir):
             missing.append(required)
     if missing:
         raise InvalidRepo(
-            f"Folders {', '.join(missing)} must exist; is this an OpenSAFELY repo?"
+            f"Folders {', '.join(missing)} must exist; is this an OpenSAFELY repo?",
+            report_args=True,
         )
     for path in workdir.rglob("*"):
         path = str(path)
@@ -79,7 +80,8 @@ def validate_input_files(workdir):
             "application/pdf"
         ):
             raise InvalidRepo(
-                f"All analysis input files must be text, found {result} at {path}"
+                f"All analysis input files must be text, found {result} at {path}",
+                report_args=True,
             )
 
 
@@ -140,7 +142,7 @@ def run_cohort_extractor(job):
         if result.returncode == 0:
             joblogger.info("cohort-extractor subdocker stdout: %s", result.stdout)
         else:
-            raise CohortExtractorError(result.stderr)
+            raise CohortExtractorError(result.stderr, report_args=False)
         job["output_url"] = str(output_path)
         return job
 
@@ -178,12 +180,12 @@ def fetch_study_source(workdir, job):
             break
         except subprocess.CalledProcessError as e:
             if "not found" in e.output:
-                raise RepoNotFound(e.output)
+                raise RepoNotFound(e.output, report_args=True)
             elif attempt < max_retries:
                 joblogger.warning("Failed clone; sleeping, then retrying")
                 time.sleep(10)
             else:
-                raise GitCloneError(cmd) from e
+                raise GitCloneError(cmd, report_args=True) from e
 
 
 def report_result(future):

--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -41,7 +41,11 @@ def job_id_from_job(job):
     """An opaque string for use in logging to help trace events related to
     a specific job
     """
-    return "job#" + re.match(r".*/([0-9]+)/?$", job["url"]).groups()[0]
+    match = re.match(r".*/([0-9]+)/?$", job["url"])
+    if match:
+        return "job#" + match.groups()[0]
+    else:
+        return "-"
 
 
 def get_job_logger(job):

--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -231,7 +231,7 @@ def report_result(future):
             job["url"],
             json={
                 "status_code": 99,
-                "status_message": "Unclassified error {id_message}",
+                "status_message": f"Unclassified error {id_message}",
             },
             auth=get_auth(),
         )

--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -219,9 +219,10 @@ def report_result(future):
             auth=get_auth(),
         )
         joblogger.info(
-            "Reported error %s (%s) to job server",
+            "Reported error %s (%s %s) to job server",
             error.status_code,
-            f"{repr(error)} {id_message}",
+            error,
+            id_message,
         )
         # Remove pebble's RemoteTraceback exception from reporting
         error.__cause__ = None

--- a/runner/exceptions.py
+++ b/runner/exceptions.py
@@ -2,7 +2,7 @@
 
 All exceptions should subclass OpenSafelyError
 
-`safe_args` indicates if it is OK for any arguments to be sent to
+`report_args` indicates if it is OK for any arguments to be sent to
 people outside the secure platform.
 
 """
@@ -11,43 +11,39 @@ people outside the secure platform.
 class OpenSafelyError(Exception):
     safe_args = False
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, report_args=None, **kwargs):
+        assert report_args is not None, "`report_args` keyword arg must be supplied"
+        self.report_args = report_args
         assert self.status_code not in [-1, 99], "status_codes -1 and 99 are reserved"
         super().__init__(*args, **kwargs)
 
     def safe_details(self):
         classname = type(self).__name__
-        if self.safe_args:
+        if self.report_args:
             return classname + ": " + " ".join(self.args)
         else:
             return classname + ": [possibly-unsafe details redacted]"
 
 
 class DockerError(OpenSafelyError):
-    safe_args = False
     status_code = 1
 
 
 class DockerRunError(DockerError):
-    safe_args = False
     status_code = 3
 
 
 class CohortExtractorError(DockerRunError):
-    safe_args = False
     status_code = 4
 
 
 class RepoNotFound(OpenSafelyError):
-    safe_args = True
     status_code = 5
 
 
 class InvalidRepo(OpenSafelyError):
-    safe_args = True
     status_code = 6
 
 
 class GitCloneError(OpenSafelyError):
-    safe_args = True
     status_code = 7

--- a/runner/exceptions.py
+++ b/runner/exceptions.py
@@ -1,26 +1,53 @@
+"""Custom exceptions to aid safe error reporting.
+
+All exceptions should subclass OpenSafelyError
+
+`safe_args` indicates if it is OK for any arguments to be sent to
+people outside the secure platform.
+
+"""
+
+
 class OpenSafelyError(Exception):
-    pass
+    safe_args = False
+
+    def __init__(self, *args, **kwargs):
+        assert self.status_code not in [-1, 99], "status_codes -1 and 99 are reserved"
+        super().__init__(*args, **kwargs)
+
+    def safe_details(self):
+        classname = type(self).__name__
+        if self.safe_args:
+            return classname + ": " + " ".join(self.args)
+        else:
+            return classname + ": [possibly-unsafe details redacted]"
 
 
 class DockerError(OpenSafelyError):
+    safe_args = False
     status_code = 1
 
 
 class DockerRunError(DockerError):
+    safe_args = False
     status_code = 3
 
 
 class CohortExtractorError(DockerRunError):
+    safe_args = False
     status_code = 4
 
 
 class RepoNotFound(OpenSafelyError):
+    safe_args = True
     status_code = 5
 
 
 class InvalidRepo(OpenSafelyError):
+    safe_args = True
     status_code = 6
 
 
 class GitCloneError(OpenSafelyError):
+    safe_args = True
     status_code = 7

--- a/runner/exceptions.py
+++ b/runner/exceptions.py
@@ -6,10 +6,6 @@ class DockerError(OpenSafelyError):
     status_code = 1
 
 
-class BadDockerImageName(DockerError):
-    status_code = 2
-
-
 class DockerRunError(DockerError):
     status_code = 3
 

--- a/runner/exceptions.py
+++ b/runner/exceptions.py
@@ -1,0 +1,30 @@
+class OpenSafelyError(Exception):
+    pass
+
+
+class DockerError(OpenSafelyError):
+    status_code = 1
+
+
+class BadDockerImageName(DockerError):
+    status_code = 2
+
+
+class DockerRunError(DockerError):
+    status_code = 3
+
+
+class CohortExtractorError(DockerRunError):
+    status_code = 4
+
+
+class RepoNotFound(OpenSafelyError):
+    status_code = 5
+
+
+class InvalidRepo(OpenSafelyError):
+    status_code = 6
+
+
+class GitCloneError(OpenSafelyError):
+    status_code = 7

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -63,7 +63,10 @@ def test_watch_broken_job(mock_env):
         adapter = m.patch("/jobs/0/")
         runner.watch("http://test.com/jobs/", loop=False)
         assert adapter.request_history[0].json() == {"started": True}
-        assert adapter.request_history[1].json() == {"status_code": 1}
+        assert adapter.request_history[1].json() == {
+            "status_code": 99,
+            "status_message": "Unclassified error id job#0",
+        }
 
 
 @patch("runner.run_cohort_extractor", dummy_working_job)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3,6 +3,10 @@ import runner
 from unittest.mock import patch
 import time
 
+from runner import make_volume_name
+from runner import run_cohort_extractor
+from runner.exceptions import BadDockerImageName
+
 import pytest
 
 
@@ -50,7 +54,7 @@ def dummy_slow_job(job):
     return dummy_working_job(job, sleep=True)
 
 
-@patch("runner.run_job", dummy_broken_job)
+@patch("runner.run_cohort_extractor", dummy_broken_job)
 def test_watch_broken_job(mock_env):
     with requests_mock.Mocker() as m:
         m.get("/jobs/", json=test_job())
@@ -60,7 +64,7 @@ def test_watch_broken_job(mock_env):
         assert adapter.request_history[1].json() == {"status_code": 1}
 
 
-@patch("runner.run_job", dummy_working_job)
+@patch("runner.run_cohort_extractor", dummy_working_job)
 def test_watch_working_job(mock_env):
     with requests_mock.Mocker() as m:
         m.get("/jobs/", json=test_job())
@@ -73,7 +77,7 @@ def test_watch_working_job(mock_env):
         }
 
 
-@patch("runner.run_job", dummy_slow_job)
+@patch("runner.run_cohort_extractor", dummy_slow_job)
 @patch("runner.HOUR", 0.001)
 def test_watch_timeout_job(mock_env):
     with requests_mock.Mocker() as m:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -89,8 +89,11 @@ def test_watch_timeout_job(mock_env):
         m.get("/jobs/", json=test_job())
         adapter = m.patch("/jobs/0/")
         runner.watch("http://test.com/jobs/", loop=False)
-        assert adapter.request_history[0].json() == {"started": True}
-        assert adapter.request_history[1].json() == {"status_code": -1}
+        assert adapter.request_history[0].json()["started"] is True
+        assert adapter.request_history[1].json() == {
+            "status_code": -1,
+            "status_message": "TimeoutError(86400s) id job#0",
+        }
 
 
 def test_make_volume_name():

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -98,9 +98,5 @@ def test_make_volume_name():
 
 
 def test_bad_volume_name_raises():
-    bad_name = "-badname"
-    with pytest.raises(BadDockerImageName) as e:
-        run_cohort_extractor(
-            {"repo": bad_name, "tag": "thing", "db": "FULL", "url": ""}
-        )
-    assert e.value.args == (f"Bad image name {bad_name}",)
+    bad_name = "/badname"
+    assert make_container_name(bad_name) == "badname"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -86,3 +86,21 @@ def test_watch_timeout_job(mock_env):
         runner.watch("http://test.com/jobs/", loop=False)
         assert adapter.request_history[0].json() == {"started": True}
         assert adapter.request_history[1].json() == {"status_code": -1}
+
+
+def test_make_volume_name():
+    repo = "https://github.com/opensafely/hiv-research/"
+    branch = "feasibility-no"
+    db_flavour = "full"
+    assert (
+        make_volume_name(repo, branch, db_flavour) == "hiv-research-feasibility-no-full"
+    )
+
+
+def test_bad_volume_name_raises():
+    bad_name = "-badname"
+    with pytest.raises(BadDockerImageName) as e:
+        run_cohort_extractor(
+            {"repo": bad_name, "tag": "thing", "db": "FULL", "url": ""}
+        )
+    assert e.value.args == (f"Bad image name {bad_name}",)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -110,19 +110,17 @@ def test_bad_volume_name_raises():
     assert make_container_name(bad_name) == "badname"
 
 
-def test_docker_exception():
-    error = CohortExtractorError("thing not to leak")
-    assert (
-        error.safe_details()
-        == "CohortExtractorError: [possibly-unsafe details redacted]"
-    )
-    assert repr(error) == "CohortExtractorError('thing not to leak')"
+def test_exception_reporting():
+    class TestError(OpenSafelyError):
+        status_code = 10
 
+    error = TestError("thing not to leak", report_args=False)
+    assert error.safe_details() == "TestError: [possibly-unsafe details redacted]"
+    assert repr(error) == "TestError('thing not to leak')"
 
-def test_opensafely_exception():
-    error = RepoNotFound("thing OK to leak")
-    assert error.safe_details() == "RepoNotFound: thing OK to leak"
-    assert repr(error) == "RepoNotFound('thing OK to leak')"
+    error = TestError("thing OK to leak", report_args=True)
+    assert error.safe_details() == "TestError: thing OK to leak"
+    assert repr(error) == "TestError('thing OK to leak')"
 
 
 def test_reserved_exception():
@@ -130,8 +128,8 @@ def test_reserved_exception():
         status_code = -1
 
     with pytest.raises(AssertionError) as e:
-        raise InvalidError()
+        raise InvalidError(report_args=True)
     assert "reserved" in e.value.args[0]
 
     with pytest.raises(RepoNotFound):
-        raise RepoNotFound()
+        raise RepoNotFound(report_args=True)


### PR DESCRIPTION
Provide specific errors for common error cases.

Where specific exceptions are not used, we return a deliberately
uninformative message, to avoid leaking potentially sensitive

Also, add a specific id to every log message associated
with a job.

