### PR TITLE
Move API Under Prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ lint:
 
 .PHONY: run
 run:
-	python run.py watch https://jobs.opensafely.org/jobs
+	python run.py watch https://jobs.opensafely.org/api/jobs
 
 .PHONY: setup
 setup:


### PR DESCRIPTION
This moves the API under a `/api` prefix so the web UI can take over the un-prefixed URLs.  Pretty URLs for the humans!

It needs to be merged and deployed in conjunction with opensafely/job-server#30