### PR TITLE
Refactor Loading project.yaml

### DIFF
--- a/jobrunner/project.py
+++ b/jobrunner/project.py
@@ -61,7 +61,7 @@ def variables_in_string(string_with_variables, variable_name_only=False):
         return [x[0] for x in matches]
 
 
-def load_and_validate_project(workdir):
+def validate_project(workdir):
     """Check that a dictionary of project actions is valid"""
     with open(os.path.join(workdir, "project.yaml"), "r") as f:
         project = yaml.safe_load(f)
@@ -277,7 +277,7 @@ def parse_project_yaml(workdir, job_spec):
     exception is raised.
 
     """
-    project = load_and_validate_project(workdir)
+    project = validate_project(workdir)
     project_actions = project["actions"]
     requested_action_id = job_spec["action_id"]
     if requested_action_id not in project_actions:

--- a/jobrunner/project.py
+++ b/jobrunner/project.py
@@ -61,11 +61,8 @@ def variables_in_string(string_with_variables, variable_name_only=False):
         return [x[0] for x in matches]
 
 
-def validate_project(workdir):
+def validate_project(workdir, project):
     """Check that a dictionary of project actions is valid"""
-    with open(os.path.join(workdir, "project.yaml"), "r") as f:
-        project = yaml.safe_load(f)
-
     expected_version = project.get("version", None)
     if expected_version != "1.0":
         raise ProjectValidationError(
@@ -277,7 +274,11 @@ def parse_project_yaml(workdir, job_spec):
     exception is raised.
 
     """
-    project = validate_project(workdir)
+    with open(os.path.join(workdir, "project.yaml"), "r") as f:
+        project = yaml.safe_load(f)
+
+    project = validate_project(workdir, project)
+
     project_actions = project["actions"]
     requested_action_id = job_spec["action_id"]
     if requested_action_id not in project_actions:

--- a/jobrunner/project.py
+++ b/jobrunner/project.py
@@ -133,7 +133,6 @@ def validate_project(workdir, project):
                 raise ProjectValidationError(
                     f"Unable to find variable {v}", report_args=True
                 )
-    return project
 
 
 def interpolate_variables(args, dependency_actions):
@@ -277,7 +276,7 @@ def parse_project_yaml(workdir, job_spec):
     with open(os.path.join(workdir, "project.yaml"), "r") as f:
         project = yaml.safe_load(f)
 
-    project = validate_project(workdir, project)
+    validate_project(workdir, project)
 
     project_actions = project["actions"]
     requested_action_id = job_spec["action_id"]

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -5,11 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from jobrunner.exceptions import ProjectValidationError
-from jobrunner.project import (
-    load_and_validate_project,
-    make_container_name,
-    parse_project_yaml,
-)
+from jobrunner.project import make_container_name, parse_project_yaml, validate_project
 
 
 def test_bad_volume_name_is_corrected():
@@ -121,7 +117,7 @@ def test_duplicate_action_id_in_project():
     """
     project_path = "tests/fixtures/invalid_project_1"
     with pytest.raises(ProjectValidationError, match="appears more than once"):
-        load_and_validate_project(project_path)
+        validate_project(project_path)
 
 
 def test_invalid_run_in_project():
@@ -131,7 +127,7 @@ def test_invalid_run_in_project():
     """
     project_path = "tests/fixtures/invalid_project_2"
     with pytest.raises(ProjectValidationError, match="not a supported command"):
-        load_and_validate_project(project_path)
+        validate_project(project_path)
 
 
 def test_project_output_missing_raises_exception():
@@ -141,7 +137,7 @@ def test_project_output_missing_raises_exception():
     """
     project_path = "tests/fixtures/invalid_project_3"
     with pytest.raises(ProjectValidationError, match="Unable to find variable"):
-        load_and_validate_project(project_path)
+        validate_project(project_path)
 
 
 def test_bad_variable_path_raises_exception():
@@ -150,7 +146,7 @@ def test_bad_variable_path_raises_exception():
     """
     project_path = "tests/fixtures/invalid_project_4"
     with pytest.raises(ProjectValidationError, match="Unable to find variable"):
-        load_and_validate_project(project_path)
+        validate_project(project_path)
 
 
 def test_bad_version_raises_exception():
@@ -159,7 +155,7 @@ def test_bad_version_raises_exception():
     """
     project_path = "tests/fixtures/invalid_project_5"
     with pytest.raises(ProjectValidationError, match="must have a version specified"):
-        load_and_validate_project(project_path)
+        validate_project(project_path)
 
 
 def test_invalid_output_file_raises_exception():
@@ -168,4 +164,4 @@ def test_invalid_output_file_raises_exception():
     """
     project_path = "tests/fixtures/invalid_project_6"
     with pytest.raises(ProjectValidationError, match="is not permitted"):
-        load_and_validate_project(project_path)
+        validate_project(project_path)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,8 +1,10 @@
 import os
 import tempfile
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+import yaml
 
 from jobrunner.exceptions import ProjectValidationError
 from jobrunner.project import make_container_name, parse_project_yaml, validate_project
@@ -116,8 +118,12 @@ def test_duplicate_action_id_in_project():
 
     """
     project_path = "tests/fixtures/invalid_project_1"
+
+    with open(Path(project_path) / "project.yaml", "r") as f:
+        project = yaml.safe_load(f)
+
     with pytest.raises(ProjectValidationError, match="appears more than once"):
-        validate_project(project_path)
+        validate_project(project_path, project)
 
 
 def test_invalid_run_in_project():
@@ -126,8 +132,12 @@ def test_invalid_run_in_project():
 
     """
     project_path = "tests/fixtures/invalid_project_2"
+
+    with open(Path(project_path) / "project.yaml", "r") as f:
+        project = yaml.safe_load(f)
+
     with pytest.raises(ProjectValidationError, match="not a supported command"):
-        validate_project(project_path)
+        validate_project(project_path, project)
 
 
 def test_project_output_missing_raises_exception():
@@ -136,8 +146,12 @@ def test_project_output_missing_raises_exception():
 
     """
     project_path = "tests/fixtures/invalid_project_3"
+
+    with open(Path(project_path) / "project.yaml", "r") as f:
+        project = yaml.safe_load(f)
+
     with pytest.raises(ProjectValidationError, match="Unable to find variable"):
-        validate_project(project_path)
+        validate_project(project_path, project)
 
 
 def test_bad_variable_path_raises_exception():
@@ -145,8 +159,12 @@ def test_bad_variable_path_raises_exception():
 
     """
     project_path = "tests/fixtures/invalid_project_4"
+
+    with open(Path(project_path) / "project.yaml", "r") as f:
+        project = yaml.safe_load(f)
+
     with pytest.raises(ProjectValidationError, match="Unable to find variable"):
-        validate_project(project_path)
+        validate_project(project_path, project)
 
 
 def test_bad_version_raises_exception():
@@ -154,8 +172,12 @@ def test_bad_version_raises_exception():
 
     """
     project_path = "tests/fixtures/invalid_project_5"
+
+    with open(Path(project_path) / "project.yaml", "r") as f:
+        project = yaml.safe_load(f)
+
     with pytest.raises(ProjectValidationError, match="must have a version specified"):
-        validate_project(project_path)
+        validate_project(project_path, project)
 
 
 def test_invalid_output_file_raises_exception():
@@ -163,5 +185,9 @@ def test_invalid_output_file_raises_exception():
 
     """
     project_path = "tests/fixtures/invalid_project_6"
+
+    with open(Path(project_path) / "project.yaml", "r") as f:
+        project = yaml.safe_load(f)
+
     with pytest.raises(ProjectValidationError, match="is not permitted"):
-        validate_project(project_path)
+        validate_project(project_path, project)


### PR DESCRIPTION
This does a pure refactor to split apart loading a `project.yaml` and validating it.

As part of opensafely/job-server#61 we want to get the actions defined in a `project.yaml`.  Downloading a file from GitHub via their API gives us the file contents  so rather than saving to disk just to read it into `load_and_validate_project` it makes sense to break up those two bits of functionality.

I'm expecting to add validation to the web flow later, to add an extra layer of checks on invalid `project.yaml` reaching job-runner.