### PR TITLE
fix: use status_code to determine something is running

### DIFF
--- a/jobrunner/server_interaction.py
+++ b/jobrunner/server_interaction.py
@@ -110,7 +110,11 @@ def start_dependent_job_or_raise_if_unfinished(dependency_action):
             dependency_status["pk"],
             dependency_status,
         )
-
+        if dependency_status["status_code"] == DependencyRunning.status_code:
+            raise DependencyRunning(
+                f"Not started because dependency `{dependency_action['action_id']}` is currently running",
+                report_args=True,
+            )
         if dependency_status["completed_at"]:
 
             if dependency_status["force_run"]:


### PR DESCRIPTION
Previously we relied on `started` having been set to `False` as one of
the conditions for remaining in a `pending` meta-state.

However, this flag is set and unset by the main loop and may be in an
inconsistent state. The `status_code`, on the other hand, will remain
that of `DependencyRunning` until the related job completes, leading to
a lower likelihood of inconsistent state.