### PR TITLE
Avoid including token in repo URL

### DIFF
--- a/jobrunner/git_askpass_access_token.py
+++ b/jobrunner/git_askpass_access_token.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+"""
+Minimal askpass implementation that can be supplied as the value of GIT_ASKPASS
+and will return the access token as the username when invoked. This allows us
+to avoid embedding the token in the repo URL (where it leaks easily) or writing
+it to disk.
+"""
+import os, sys
+
+if __name__ == "__main__":
+    if sys.argv[1].startswith("Username"):
+        print(os.environ.get("PRIVATE_REPO_ACCESS_TOKEN", ""))

--- a/jobrunner/job.py
+++ b/jobrunner/job.py
@@ -6,7 +6,6 @@ import shutil
 import subprocess
 import tempfile
 import time
-import urllib
 from pathlib import Path
 
 from jobrunner.exceptions import (
@@ -21,20 +20,6 @@ from jobrunner.server_interaction import start_dependent_job_or_raise_if_unfinis
 from jobrunner.utils import getlogger, safe_join, writable_job_subset
 
 logger = getlogger(__name__)
-
-
-def add_github_auth_to_repo(repo):
-    """Add Basic HTTP Auth to a Github repo, from the environment.
-
-    For example, `https://github.com/sebbacon/test.git` becomes `https:/<access_token>@github.com/sebbacon/test.git`
-    """
-    parts = urllib.parse.urlparse(repo)
-    assert not parts.username and not parts.password
-    return urllib.parse.urlunparse(
-        parts._replace(
-            netloc=f"{os.environ['PRIVATE_REPO_ACCESS_TOKEN']}@{parts.netloc}"
-        )
-    )
 
 
 def fix_ownership(path):
@@ -248,12 +233,6 @@ class Job:
         branch = self.job_spec["workspace"]["branch"]
         max_retries = 5
         sleep = 4
-        # We use URL-based authentication to access private repos
-        # (q.v. `add_github_auth_to_repo`, above).
-        #
-        # Because `git clone` causes these URLs to be written to disk
-        # (in `~/.git/config`), we instead use `git pull`, which
-        # requires a folder to be initialised as a git repo
         os.makedirs(self.workdir, exist_ok=True)
         os.chdir(self.workdir)
         subprocess.check_call(["git", "init"])
@@ -267,32 +246,36 @@ class Job:
                     "pull",
                     "--depth",
                     "1",
-                    add_github_auth_to_repo(repo),
+                    repo,
                     branch,
                 ]
-                self.logger.info(
-                    "Running %s, attempt %s", redact_token(" ".join(cmd)), attempt
+                self.logger.info("Running %s, attempt %s", " ".join(cmd), attempt)
+                subprocess.check_output(
+                    cmd,
+                    stderr=subprocess.STDOUT,
+                    encoding="utf8",
+                    env=dict(
+                        os.environ,
+                        # This script will supply the access token from the
+                        # environment variable PRIVATE_REPO_ACCESS_TOKEN
+                        GIT_ASKPASS=os.path.join(
+                            os.path.dirname(__file__), "git_askpass_access_token.py"
+                        ),
+                    ),
                 )
-                subprocess.check_output(cmd, stderr=subprocess.STDOUT, encoding="utf8")
                 break
             except subprocess.CalledProcessError as e:
                 if e.output and "not found" in e.output:
-                    raise RepoNotFound(redact_token(e.output), report_args=True)
+                    raise RepoNotFound(e.output, report_args=True)
                 elif attempt < max_retries:
                     self.logger.warning(
                         "Failed clone to %s (message `%s`); sleeping %s, then retrying",
                         self.workdir,
-                        redact_token(e.output),
+                        e.output,
                         sleep,
                     )
                     shutil.rmtree(self.workdir, ignore_errors=True)
                     time.sleep(sleep)
                     sleep *= 2
                 else:
-                    raise GitCloneError(
-                        redact_token(" ".join(cmd)), report_args=True
-                    ) from e
-
-
-def redact_token(s):
-    return s.replace(os.environ["PRIVATE_REPO_ACCESS_TOKEN"], "xxxxxxxxx")
+                    raise GitCloneError(" ".join(cmd), report_args=True) from e


### PR DESCRIPTION
Previously we tried to redact the token from anywhere it might leak to,
but this is fiddly and error prone. Git doesn't directly support
supplying the token in an environment variable, but it does allow us to
specify a custom "askpass" executable which can grab the token from the
environment for us.