### PR TITLE
fix: Correctly separate env var arguments

### DIFF
--- a/jobrunner/project.py
+++ b/jobrunner/project.py
@@ -258,8 +258,8 @@ def add_runtime_metadata(
         if job_config["backend"] == "expectations":
             user_args.append("--expectations-population=100000")
         else:
-            docker_args.append("-e DATABASE_URL={database_url}")
-            docker_args.append("-e TEMP_DATABASE_NAME={temp_database_name}")
+            docker_args.extend(["-e", "DATABASE_URL={database_url}"])
+            docker_args.extend(["-e", "TEMP_DATABASE_NAME={temp_database_name}"])
         cohort_output_location = job_config["output_locations"][0]["relative_path"]
         output_dir = os.path.join("/workspace", os.path.dirname(cohort_output_location))
         user_args.append(f"--output-dir={output_dir}")

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -25,8 +25,10 @@ def test_job_to_project_nodeps(job_spec_maker):
 
     project = parse_project_yaml(project_path, job_spec)
     assert project["docker_invocation"] == [
-        "-e DATABASE_URL=sqlite:///test.db",
-        "-e TEMP_DATABASE_NAME=temp",
+        "-e",
+        "DATABASE_URL=sqlite:///test.db",
+        "-e",
+        "TEMP_DATABASE_NAME=temp",
         "docker.opensafely.org/cohortextractor:0.5.2",
         "generate_cohort",
         "--output-dir=/workspace/",
@@ -57,8 +59,10 @@ def test_valid_run_in_project(job_spec_maker):
     job_spec = job_spec_maker(action_id="generate_cohort")
     project = parse_project_yaml(project_path, job_spec)
     assert project["docker_invocation"] == [
-        "-e DATABASE_URL=sqlite:///test.db",
-        "-e TEMP_DATABASE_NAME=temp",
+        "-e",
+        "DATABASE_URL=sqlite:///test.db",
+        "-e",
+        "TEMP_DATABASE_NAME=temp",
         "docker.opensafely.org/cohortextractor:0.5.2",
         "generate_cohort",
         "--output-dir=/workspace/",


### PR DESCRIPTION
Because the arguments aren't being processed by a shell (which is good)
having a space between an `-e` and its value is not sufficient:
they must be passed as separate arguments.