### PR TITLE
Use docker's built in PID 1 init process

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ jobs.
 
 Jobs belong to a `workspace`. This describes the git repo containing the
 OpenSAFELY-compliant project under execution; the git branch, and kind of
-database to use. The workspace also accts as a kind of namespace for
+database to use. The workspace also acts as a kind of namespace for
 partitioning outputs of its jobs.
 
 An OpenSAFELY-compliant project must provide a `project.yaml` file which

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,10 @@
-version: "3.6"
+version: "3.7"
 services:
   job-runner:
     build: .
     image: docker.opensafely.org/job-runner:latest
+    init: true
+    restart: unless-stopped
     environment:
       # The job server endpoint
       - JOB_SERVER_ENDPOINT=${OPENSAFELY_JOB_SERVER_ENDPOINT}
@@ -25,7 +27,6 @@ services:
       - POLL_INTERVAL=${OPENSAFELY_POLL_INTERVAL}
       # Parallelism
       - MAX_WORKERS=${OPENSAFELY_MAX_WORKERS}
-
     volumes:
       - type: bind
         source: ${OPENSAFELY_MEDIUM_PRIVACY_STORAGE_BASE}

--- a/jobrunner/job.py
+++ b/jobrunner/job.py
@@ -289,6 +289,7 @@ class Job:
                     "docker",
                     "run",
                     "--rm",
+                    "--init",
                     "--name",
                     prepared_job["container_name"],
                     "--volume",


### PR DESCRIPTION
Also enabled service restarts, which means the job-server become more of a
proper service in production.

PID 1 is special, and python doesn't always behave correctly as PID 1 wrt its
children. Docker includes tini, a PID 1 runner that behaves as expected and
runs your process and passes on signals and does process reaping properly.

You can use via `docker run --init` or via `init: true` in docker-compose.yaml.

Good explanation here: https://github.com/krallin/tini/issues/8

So, this enables init for job-runner, and also for jobs themselves. It may not
be related to the lock ups we've seen, but it very well could be, and it's
recommended best practise for docker daemons anyway.