### PR TITLE
ci: fix volume cleanup for slow docker

### DIFF
--- a/jobrunner/job.py
+++ b/jobrunner/job.py
@@ -125,8 +125,6 @@ def volume_from_filespec(input_file_spec):
     finally:
         cmd = ["docker", "stop", volume_container_name]
         subprocess.check_call(cmd)
-        cmd = ["docker", "wait", volume_container_name]
-        subprocess.check_call(cmd)
         # docker volumes are reference counted, apparently
         # non-deterministically, so wait to ensure that the docker daemon has
         # decremented the volume count, or we can not remove it.

--- a/jobrunner/job.py
+++ b/jobrunner/job.py
@@ -125,6 +125,12 @@ def volume_from_filespec(input_file_spec):
     finally:
         cmd = ["docker", "stop", volume_container_name]
         subprocess.check_call(cmd)
+        cmd = ["docker", "wait", volume_container_name]
+        subprocess.check_call(cmd)
+        # docker volumes are reference counted, apparently
+        # non-deterministically, so wait to ensure that the docker daemon has
+        # decremented the volume count, or we can not remove it.
+        time.sleep(0.1)
         cmd = ["docker", "volume", "rm", volume_name]
         subprocess.check_call(cmd)
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -3,18 +3,18 @@ import pytest
 from jobrunner.exceptions import OpenSafelyError, RepoNotFound
 
 
-class TestError(OpenSafelyError):
+class MyError(OpenSafelyError):
     status_code = 10
 
 
 def test_exception_reporting():
-    error = TestError("thing not to leak", report_args=False)
-    assert error.safe_details() == "TestError: [possibly-unsafe details redacted]"
-    assert repr(error) == "TestError('thing not to leak')"
+    error = MyError("thing not to leak", report_args=False)
+    assert error.safe_details() == "MyError: [possibly-unsafe details redacted]"
+    assert repr(error) == "MyError('thing not to leak')"
 
-    error = TestError("thing OK to leak", report_args=True)
-    assert error.safe_details() == "TestError: thing OK to leak"
-    assert repr(error) == "TestError('thing OK to leak')"
+    error = MyError("thing OK to leak", report_args=True)
+    assert error.safe_details() == "MyError: thing OK to leak"
+    assert repr(error) == "MyError('thing OK to leak')"
 
 
 def test_reserved_exception():

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -17,7 +17,7 @@ from jobrunner.job import Job, copy_from_container, volume_from_filespec
 from tests.common import default_job, test_job_list
 
 
-class TestError(OpenSafelyError):
+class MyError(OpenSafelyError):
     status_code = 10
 
 
@@ -34,13 +34,13 @@ def workspace():
 
 
 def test_exception_reporting():
-    error = TestError("thing not to leak", report_args=False)
-    assert error.safe_details() == "TestError: [possibly-unsafe details redacted]"
-    assert repr(error) == "TestError('thing not to leak')"
+    error = MyError("thing not to leak", report_args=False)
+    assert error.safe_details() == "MyError: [possibly-unsafe details redacted]"
+    assert repr(error) == "MyError('thing not to leak')"
 
-    error = TestError("thing OK to leak", report_args=True)
-    assert error.safe_details() == "TestError: thing OK to leak"
-    assert repr(error) == "TestError('thing OK to leak')"
+    error = MyError("thing OK to leak", report_args=True)
+    assert error.safe_details() == "MyError: thing OK to leak"
+    assert repr(error) == "MyError('thing OK to leak')"
 
 
 def test_reserved_exception():

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -89,7 +89,7 @@ def test_project_needs_run(dummy_output_paths, job_spec_maker):
 
     # Check using output paths that don't exist, so run is needed
     dummy_output_paths.return_value = [
-        {"base_path": "", "namespace": "", "relative_path": "x"}
+        {"base_path": "", "namespace": "", "relative_path": "test-xxx"}
     ]
     parsed = parse_project_yaml(project_path, job_spec)
     assert parsed["needs_run"] is True


### PR DESCRIPTION
When docker ref counts volumes asynchronously, so can some times take a short
while after a container is stopped before the volume can be deleted.

Also, renamed test exceptions in not be parsed as test cases, and fixed a dummy
filename to avoid potential clashes.