### PR TITLE
fix: Fix two-step git checkout

### DIFF
--- a/jobrunner/job.py
+++ b/jobrunner/job.py
@@ -363,7 +363,7 @@ class Job:
                 )
                 # This two-step fetch+checkout appears to mitigate
                 # https://github.com/opensafely/job-runner/issues/5
-                cmd = ["git", "--work-tree=.", "checkout", "--force", branch]
+                cmd = ["git", "--work-tree=.", "checkout", "--force", "FETCH_HEAD"]
                 subprocess.check_output(
                     cmd,
                     stderr=subprocess.STDOUT,


### PR DESCRIPTION
Because we're not doing a full clone, git doesn't know what `master`
refers to when we try to checkout. But we can tell it to checkout the
commit it just fetched using `FETCH_HEAD`.