### PR TITLE
Translate Cross System ID Field Name

### DIFF
--- a/jobrunner/sync.py
+++ b/jobrunner/sync.py
@@ -87,12 +87,11 @@ def job_to_remote_format(job):
     Convert our internal representation of a Job into whatever format the
     job-server expects
     """
-    return {
+    data = {
         key: value
         for (key, value) in job.asdict().items()
         if key
         in [
-            "id",
             "job_request_id",
             "action",
             "status",
@@ -103,6 +102,11 @@ def job_to_remote_format(job):
             "completed_at",
         ]
     }
+
+    # convert cross-system identifier key
+    data["identifier"] = job.id
+
+    return data
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This translates job-server's internal `Job.id` field _name_ to `runner_id` when talking to the API.  job-server maintains an internal primary key for Jobs, tracking the cross-system identifier in the runner_id field.

@evansd – we've used `identifier` for `JobRequest`'s cross-system ID, should we standard to that for both?  (happy to hold off on this PR to do that!)