### PR TITLE
Remove Active Filter

### DIFF
--- a/jobrunner/sync.py
+++ b/jobrunner/sync.py
@@ -30,7 +30,7 @@ def sync():
         # We're deliberately not paginating here on the assumption that the set
         # of active jobs is always going to be small enough that we can fetch
         # them in a single request and we don't need the extra complexity
-        params={"active": "true", "backend": config.BACKEND},
+        params={"backend": config.BACKEND},
     )["results"]
     job_requests = [job_request_from_remote_format(i) for i in results]
     job_request_ids = [i.id for i in job_requests]


### PR DESCRIPTION
This removes the `?active=true` filter since job-server only returns active `JobRequest`s.

I've also configured the API URL as part of the integration test so it's stable during test and local configuration doesn't affect it.