### PR TITLE
Refer to default branch with HEAD

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -37,7 +37,7 @@ def test_integration(tmp_work_dir, docker_cleanup, requests_mock, monkeypatch):
                     "workspace": {
                         "name": "testing",
                         "repo": str(repo_path),
-                        "branch": "master",
+                        "branch": "HEAD",
                         "db": "dummy",
                     },
                 }


### PR DESCRIPTION
The default repo for a branch can be configured globally via
init.defaultBranch.  Rather than relying on a user's default branch
matching our expectations, this uses HEAD to pick whatever is in use
locally.

Fixes #80 