### PR TITLE
Fix our sdist packaging

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,12 +59,18 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.8
-    - name: Install wheel package
-      run: |
-        pip install wheel
     - name: Build package
       run: |
+        pip install wheel
         python setup.py sdist bdist_wheel
+    - name: Check that wheel installs
+      run: |
+        python -m venv test-wheel
+        test-wheel/bin/pip install dist/*.whl
+    - name: Check that sdist installs
+      run: |
+        python -m venv test-sdist
+        test-sdist/bin/pip install dist/*.tar.gz
 
   test-docker-build:
     runs-on: ubuntu-latest

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include jobrunner/schema.sql
 include VERSION
+include LICENSE

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include jobrunner/schema.sql
+include VERSION


### PR DESCRIPTION
We were missing the VERSION file so our wheel installed OK but the sdist didn't. I realised this when attempting to vendor the PyPI released package (which uses the sdist).

This also adds tests that the packages we build can be installed.