### PR TITLE
feat: support external stata licence configuration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,13 +19,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.dev.txt
     - name: Docker Login
-      uses: azure/docker-login@v1
-      with:
-        # It seems we can't do this with the standard GITHUB_TOKEN, but
-        # have to use a personal token with the correct permissions instead
-        login-server: docker.opensafely.org
-        username: docker
-        password: ${{ secrets.OPENSAFELY_DOCKER_PASSWORD }}
+      run: docker login ghcr.io -u docker -p ${{ secrets.DOCKER_RO_TOKEN }}
     - name: Run actual tests
       run: python -m pytest
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,11 @@ __pycache__
 .python-version
 app.log
 .env
+.venv
 .coverage
 *.egg-info/
 pip-wheel-metadata/*
 /workdir
 lib
+tests/fixtures/*/output/*
+tests/fixtures/*/metadata

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ test-verbose: $(VENV)
 run: $(VENV)
 	$(PYTHON) -m jobrunner.add_job $(REPO) $(ACTION)
 
-
 lib:
 	git clone git@github.com:opensafely/job-runner-dependencies.git lib
     
@@ -32,4 +31,9 @@ update-wheels: $(VENV) requirements.txt | lib
 	rm lib/_ruamel_yaml.*.so
         
 
-
+# test the license shenanigins work when run from a console
+test-stata: $(VENV)
+	rm -f tests/fixtures/stata_project/output/env.txt
+	$(PYTHON) -c 'from jobrunner.local_run import main; main("tests/fixtures/stata_project", ["stata"])'
+	cat tests/fixtures/stata_project/output/env.txt
+	echo

--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -59,3 +59,10 @@ LOCAL_RUN_MODE = False
 
 # See `manage_jobs.ensure_overwritable` for more detail
 ENABLE_PERMISSIONS_WORKAROUND = bool(os.environ.get("ENABLE_PERMISSIONS_WORKAROUND"))
+
+STATA_LICENSE = os.environ.get("STATA_LICENCE")
+# note: git+ssh url as we want to use the user's git auth when using local_run
+STATA_LICENSE_REPO = os.environ.get(
+    "STATA_LICENCE_REPO",
+    "git+ssh://git@github.com/opensafely/server-instructions.git",
+)

--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -61,8 +61,7 @@ LOCAL_RUN_MODE = False
 ENABLE_PERMISSIONS_WORKAROUND = bool(os.environ.get("ENABLE_PERMISSIONS_WORKAROUND"))
 
 STATA_LICENSE = os.environ.get("STATA_LICENCE")
-# note: git+ssh url as we want to use the user's git auth when using local_run
 STATA_LICENSE_REPO = os.environ.get(
     "STATA_LICENCE_REPO",
-    "git+ssh://git@github.com/opensafely/server-instructions.git",
+    "https://github.com/opensafely/server-instructions.git",
 )

--- a/jobrunner/local_run.py
+++ b/jobrunner/local_run.py
@@ -179,17 +179,12 @@ def create_and_run_jobs(
         if is_stata and config.STATA_LICENSE is None:
             config.STATA_LICENSE = get_stata_license()
             if config.STATA_LICENSE is None:
-                print('You need to configure a stata licence to use stata '
-                      'actions in your project.\n'
-                      'Set the STATA_LICENCE environment variable to the '
-                      'contents of your stata.lic file.'
-                )
-                return False
+                # TODO switch this to failing when the stata image requires it
+                print('WARNING: no STATA_LICENSE found')
                 
         if not docker.image_exists_locally(image):
             print(f"Fetching missing docker image {image}")
             print(f"\nRunning: docker pull {image}")
-            import pdb; pdb.set_trace()
             try:
                 # We want to be chatty when running in the console so users can
                 # see progress and quiet in CI so we don't spam the logs with

--- a/jobrunner/local_run.py
+++ b/jobrunner/local_run.py
@@ -174,10 +174,11 @@ def create_and_run_jobs(
     jobs = find_where(Job)
 
     for image in get_docker_images(jobs):
-        if 'stata-mp' in image and config.STATA_LICENSE is None:
-            try:
-                config.STATA_LICENSE = get_stata_license()
-            except Exception as e:
+        is_stata = 'stata-mp' in image
+
+        if is_stata and config.STATA_LICENSE is None:
+            config.STATA_LICENSE = get_stata_license()
+            if config.STATA_LICENSE is None:
                 print('You need to configure a stata licence to use stata '
                       'actions in your project.\n'
                       'Set the STATA_LICENCE environment variable to the '
@@ -188,15 +189,21 @@ def create_and_run_jobs(
         if not docker.image_exists_locally(image):
             print(f"Fetching missing docker image {image}")
             print(f"\nRunning: docker pull {image}")
+            import pdb; pdb.set_trace()
             try:
                 # We want to be chatty when running in the console so users can
                 # see progress and quiet in CI so we don't spam the logs with
                 # layer download noise
                 docker.pull(image, quiet=not sys.stdout.isatty())
             except docker.DockerPullError as e:
-                print("Failed with error:")
-                print(e)
-                return False
+                success = False
+                if is_stata:
+                    # best effort retry hack
+                    success = temporary_stata_workaround(image)
+                if not success:
+                    print("Failed with error:")
+                    print(e)
+                    return False
 
     action_names = [job.action for job in jobs]
     print(f"\nRunning actions: {', '.join(action_names)}\n")
@@ -323,7 +330,7 @@ def get_log_file_snippet(log_file, max_lines):
     return "\n".join(log_lines).strip(), truncated
 
 
-def temporary_docker_auth_workaround(missing_docker_images):
+def temporary_stata_workaround(image):
     """
     This is a temporary workaround for the fact that the current crop of Github
     Actions have credentials for the old docker.opensafely.org registry but not
@@ -335,42 +342,58 @@ def temporary_docker_auth_workaround(missing_docker_images):
     commands in any case, so this will hopefully be a short-lived hack.
     """
     if not os.environ.get("GITHUB_WORKFLOW"):
-        return missing_docker_images
-    stata_images = [
-        image
-        for image in missing_docker_images
-        if image.startswith("ghcr.io/opensafely/stata-mp:")
-    ]
-    if not stata_images:
-        return missing_docker_images
-    docker_config = os.environ.get("DOCKER_CONFIG", "~/.docker")
+        return False
+
+    docker_config = os.environ.get(
+        "DOCKER_CONFIG", os.path.expanduser("~/.docker")
+    )
     config_path = Path(docker_config) / "config.json"
     try:
         config = json.loads(config_path.read_text())
         auths = config["auths"]
     except Exception:
-        return missing_docker_images
+        return False
+
     if "ghcr.io" in auths or "docker.opensafely.org" not in auths:
-        return missing_docker_images
+        return False
+
     print("Applying Docker authentication workaround...")
-    for image in stata_images:
-        alt_image = image.replace("ghcr.io/opensafely/", "docker.opensafely.org/")
+    alt_image = image.replace("ghcr.io/opensafely/", "docker.opensafely.org/")
+
+    try:
         docker.pull(alt_image, quiet=True)
         print(f"Retagging '{alt_image}' as '{image}'")
         subprocess_run(["docker", "tag", alt_image, image])
-    return [image for image in missing_docker_images if image not in stata_images]
+    except Exception:
+        return False
+
+    return True
 
 
 def get_stata_license(repo=config.STATA_LICENSE_REPO):
     """Load a stata license from local cache or remote repo."""
     cached = Path(f'{tempfile.gettempdir()}/opensafely-stata.lic')
+    repos = [repo, repo.replace('https://', 'git+ssh://git@')]
+    env = {'GIT_TERMINAL_PROMPT': '0'} 
+
+    def git_clone(repo_url, cwd):
+        cmd = ['git', 'clone', '--depth=1', repo_url, 'repo']
+        result = subprocess_run(cmd, cwd=cwd, env={'GIT_TERMINAL_PROMPT': '0'})
+        return result.returncode == 0
 
     if not cached.exists():
         try:
             tmp = tempfile.TemporaryDirectory(suffix='opensafely')
-            cmd = ['git', 'clone', '--depth=1', repo, 'repo']
-            subprocess_run(cmd, cwd=tmp.name)
+            success = git_clone(repo, tmp.name)
+            # http urls usually won't work for linux/mac clients, so try ssh
+            if not success and repo.startswith('https://'):
+                git_clone(
+                    repo.replace('https://', 'git+ssh://git@'), 
+                    tmp.name,
+                )
             shutil.copyfile(f'{tmp.name}/repo/stata.lic', cached)
+        except Exception:
+            return None
         finally:
             # py3.7 on windows can't clean up TemporaryDirectory with git's read only
             # file in them, so just don't bother.

--- a/jobrunner/manage_jobs.py
+++ b/jobrunner/manage_jobs.py
@@ -84,6 +84,8 @@ def start_job(job):
     # Prepend registry name
     image = action_args[0]
     full_image = f"{config.DOCKER_REGISTRY}/{image}"
+    if image.startswith('stata-mp'):
+        env['STATA_LICENSE'] = str(config.STATA_LICENSE)
     # Check the image exists locally and error if not. Newer versions of
     # docker-cli support `--pull=never` as an argument to `docker run` which
     # would make this simpler, but it looks like it will be a while before this

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@ import subprocess
 
 import pytest
 
+from jobrunner.database import get_connection_from_file
+
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow_test: mark test as being slow running")
@@ -64,3 +66,8 @@ def delete_docker_entities(entity, label, ignore_errors=False):
     if ids and response.returncode == 0:
         rm_args = ["docker", entity, "rm", "--force"] + ids
         subprocess.run(rm_args, capture_output=True, check=not ignore_errors)
+
+
+@pytest.fixture(autouse=True)
+def cleanup():
+    get_connection_from_file.cache_clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,8 +66,3 @@ def delete_docker_entities(entity, label, ignore_errors=False):
     if ids and response.returncode == 0:
         rm_args = ["docker", entity, "rm", "--force"] + ids
         subprocess.run(rm_args, capture_output=True, check=not ignore_errors)
-
-
-@pytest.fixture(autouse=True)
-def cleanup():
-    get_connection_from_file.cache_clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,6 @@ import subprocess
 
 import pytest
 
-from jobrunner.database import get_connection_from_file
-
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow_test: mark test as being slow running")

--- a/tests/fixtures/stata_project/analysis/model.do
+++ b/tests/fixtures/stata_project/analysis/model.do
@@ -1,0 +1,5 @@
+. local license : env STATA_LICENSE
+. file open output using "output/env.txt", write text
+. file write output "`license'" 
+. file close output
+

--- a/tests/fixtures/stata_project/project.yaml
+++ b/tests/fixtures/stata_project/project.yaml
@@ -1,0 +1,12 @@
+# minimal project to test running a stata action
+version: '3.0'
+
+expectations:
+  population_size: 100
+
+actions:
+  stata:
+    run: stata-mp:latest analysis/model.do
+    outputs:
+      highly_sensitive:
+        env: output/env.txt

--- a/tests/test_local_run.py
+++ b/tests/test_local_run.py
@@ -68,7 +68,4 @@ def test_get_stata_license_repo_fetch(systmpdir, tmp_path):
 
 
 def test_get_stata_license_repo_error(systmpdir):
-    # GH auth errors are exposed as not found errors, so this is close-ish to a
-    # real git auth failure condition.
-    with pytest.raises(Exception) as e:
-        local_run.get_stata_license('/invalid/repo')
+    assert local_run.get_stata_license('/invalid/repo') is None

--- a/tests/test_local_run.py
+++ b/tests/test_local_run.py
@@ -30,7 +30,7 @@ def test_local_run_stata(tmp_path, monkeypatch):
     project_dir = tmp_path / "project"
     shutil.copytree(project_fixture, project_dir)
     monkeypatch.setattr("jobrunner.config.STATA_LICENSE", 'env-license')
-    assert local_run.main(project_dir=project_dir, actions=["stata"])
+    local_run.main(project_dir=project_dir, actions=["stata"])
     env_file = (project_dir / "output/env.txt")
     assert env_file.read_text() == 'env-license'
 

--- a/tests/test_local_run.py
+++ b/tests/test_local_run.py
@@ -1,9 +1,12 @@
 from pathlib import Path
+import os
 import shutil
+import sys
 
 import pytest
 
 from jobrunner import local_run
+from jobrunner.subprocess_utils import subprocess_run
 
 
 @pytest.mark.slow_test
@@ -18,3 +21,54 @@ def test_local_run(tmp_path):
     assert (project_dir / "metadata/manifest.json").exists()
     assert (project_dir / "metadata/analyse_data.log").exists()
     assert not (project_dir / "metadata/.logs").exists()
+
+
+@pytest.mark.slow_test
+@pytest.mark.needs_docker
+def test_local_run_stata(tmp_path, monkeypatch):
+    project_fixture = str(Path(__file__).parent.resolve() / "fixtures/stata_project")
+    project_dir = tmp_path / "project"
+    shutil.copytree(project_fixture, project_dir)
+    monkeypatch.setattr("jobrunner.config.STATA_LICENSE", 'env-license')
+    assert local_run.main(project_dir=project_dir, actions=["stata"])
+    env_file = (project_dir / "output/env.txt")
+    assert env_file.read_text() == 'env-license'
+
+
+@pytest.fixture
+def systmpdir(monkeypatch, tmp_path):
+    """Set the system tempdir to tmp_path for this test, for isolation."""
+    monkeypatch.setattr("tempfile.tempdir", str(tmp_path))
+
+
+def test_get_stata_license_cache_exists(systmpdir, monkeypatch, tmp_path):
+
+    def fail(*a, **kwargs):
+        assert False, "should not have been called"
+
+    monkeypatch.setattr("jobrunner.subprocess_utils.subprocess_run", fail)
+    cache = tmp_path / "opensafely-stata.lic"
+    cache.write_text("cached-license")
+    assert local_run.get_stata_license() == "cached-license"
+
+
+def test_get_stata_license_repo_fetch(systmpdir, tmp_path):
+    # create a repo to clone the license from
+    repo = tmp_path / "test-repo"
+    repo.mkdir()
+    license = repo / "stata.lic"
+    license.write_text("repo-license")
+    git = ['git', '-c', 'user.name=test', '-c', 'user.email=test@example.com']
+    cwd = str(repo)
+    subprocess_run(git + ["init"], cwd=cwd) 
+    subprocess_run(git + ["add", "stata.lic"], cwd=cwd)
+    subprocess_run(git + ["commit", "-m", "test"], cwd=cwd)
+    assert local_run.get_stata_license(cwd) == "repo-license"
+    assert (tmp_path / 'opensafely-stata.lic').read_text() == "repo-license"
+
+
+def test_get_stata_license_repo_error(systmpdir):
+    # GH auth errors are exposed as not found errors, so this is close-ish to a
+    # real git auth failure condition.
+    with pytest.raises(Exception) as e:
+        local_run.get_stata_license('/invalid/repo')


### PR DESCRIPTION
A stata licence can be configured by setting a STATA_LICENCE environment
variable, which will be needed for GHA and backend server usage.

For local runs, we add a best-effort convenience method - checking out a
private repo containing the opensafely license using the current user's git
credentials. If the user has access to the repo (either an opensafely member or
external collaborator), everything should just work.  If not, they'll get an
error message telling them to set the environment variable for their stata licence.

The goal of this is so we can make the stata docker image public, and avoid the
need for any alternative credentials for users - we just need GitHub.

Note: the stata-mp image does not yet require a license - that change will land
once this one has.