### PR TITLE
fix: Improve YAML error messages

### DIFF
--- a/jobrunner/project.py
+++ b/jobrunner/project.py
@@ -78,8 +78,14 @@ def make_yaml_error_more_helpful(exc):
     goes wrong.
     """
     try:
-        exc.context_mark.name = "project.yaml"
-        exc.problem_mark.name = "project.yaml"
+        try:
+            exc.context_mark.name = "project.yaml"
+        except AttributeError:
+            pass
+        try:
+            exc.problem_mark.name = "project.yaml"
+        except AttributeError:
+            pass
         exc.note = ""
         exc.warn = ""
     except Exception:


### PR DESCRIPTION
Previously if `context_mark` was unset but `problem_mark` was set then
we'd never modify it, leading to error messages about an issue in
`<byte_string>` rather than an issue in `project.yaml`.