### PR TITLE
fix: Prevent `docker pull` from being verbose in CI

### DIFF
--- a/jobrunner/docker.py
+++ b/jobrunner/docker.py
@@ -314,14 +314,15 @@ def write_logs_to_file(container_name, filename):
         )
 
 
-def pull(image):
-    # We're deliberately not capturing stdout here as this is only used in
-    # local run mode were we want to show progress in the terminal
+def pull(image, quiet=False):
     try:
         subprocess_run(
-            ["docker", "pull", image],
+            ["docker", "pull", image, *(["--quiet"] if quiet else [])],
             check=True,
             encoding="utf-8",
+            # When not running "quiet" we don't capture stdout so that progress
+            # gets shown in the terminal
+            stdout=subprocess.PIPE if quiet else None,
             stderr=subprocess.PIPE,
         )
     except subprocess.CalledProcessError as e:

--- a/jobrunner/local_run.py
+++ b/jobrunner/local_run.py
@@ -171,7 +171,10 @@ def create_and_run_jobs(
         for image in missing_docker_images:
             print(f"\nRunning: docker pull {image}")
             try:
-                docker.pull(image)
+                # We want to be chatty when running in the console so users can
+                # see progress and quiet in CI so we don't spam the logs with
+                # layer download noise
+                docker.pull(image, quiet=not sys.stdout.isatty())
             except docker.DockerAuthError as e:
                 print("Failed with authorisation error:")
                 print(e)
@@ -339,7 +342,7 @@ def temporary_docker_auth_workaround(missing_docker_images):
     print("Applying Docker authentication workaround...")
     for image in stata_images:
         alt_image = image.replace("ghcr.io/opensafely/", "docker.opensafely.org/")
-        docker.pull(alt_image)
+        docker.pull(alt_image, quiet=True)
         print(f"Retagging '{alt_image}' as '{image}'")
         subprocess_run(["docker", "tag", alt_image, image])
     return [image for image in missing_docker_images if image not in stata_images]

--- a/jobrunner/local_run.py
+++ b/jobrunner/local_run.py
@@ -204,6 +204,9 @@ def create_and_run_jobs(
             StatusCode.DEPENDENCY_FAILED,
             StatusCode.WAITING_ON_WORKERS,
         ],
+        # All the other output we produce goes to stdout and it's a bit
+        # confusing if the log messages end up on a separate stream
+        log_to_stdout=True,
     )
 
     # Run everything

--- a/jobrunner/log_utils.py
+++ b/jobrunner/log_utils.py
@@ -13,8 +13,10 @@ import sys
 import threading
 
 
-def configure_logging(show_action_name_only=False, status_codes_to_ignore=None):
-    handler = logging.StreamHandler()
+def configure_logging(
+    show_action_name_only=False, status_codes_to_ignore=None, log_to_stdout=False
+):
+    handler = logging.StreamHandler(stream=sys.stdout if log_to_stdout else None)
     handler.addFilter(set_log_context)
     handler.setFormatter(
         JobRunnerFormatter(show_action_name_only=show_action_name_only)


### PR DESCRIPTION
We don't need to see download progress in the CI logs and it means
there's mountains of output to skip through until you get to anything
interesting.

We also now log to stdout from local_run as this is where the rest of
our output goes and it leads to confusing behaviour if output is split
across two different streams.