### PR TITLE
fix: Work around Windows permissions issues

### DIFF
--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -56,3 +56,6 @@ MAX_WORKERS = int(os.environ.get("MAX_WORKERS") or max(cpu_count() - 1, 1))
 
 # See `local_run.py` for more detail
 LOCAL_RUN_MODE = False
+
+# See `manage_jobs.ensure_overwritable` for more detail
+ENABLE_PERMISSIONS_WORKAROUND = bool(os.environ.get("ENABLE_PERMISSIONS_WORKAROUND"))


### PR DESCRIPTION
This is a (nasty) workaround for the permissions issues we hit when
switching between running the job-runner inside Docker and running it
natively on Windows. The issue is that the Docker process creates files
which the Windows native process then doesn't have permission to delete
or replace. We work around this here by using Docker to delete the
offending files for us.

This behaviour is enabled by setting the `ENABLE_PERMISSIONS_WORKAROUND`
environment variable to a non-empty value.

Note for the potentially confused: Windows permissions work nothing like
POSIX permissions. We can create new files in directories created by
Docker, we just can't modify or delete existing files.