### PR TITLE
fix: Fix redaction of subprocess arguments

### DIFF
--- a/jobrunner/git.py
+++ b/jobrunner/git.py
@@ -3,7 +3,7 @@ Utility functions for interacting with git
 """
 import logging
 import os
-from pathlib import Path
+from pathlib import Path, PurePath
 import subprocess
 import time
 from urllib.parse import urlparse, urlunparse
@@ -249,5 +249,10 @@ def redact(value, secret):
         return value.replace(secret, mask)
     elif isinstance(value, bytes):
         return value.replace(secret.encode("ascii"), mask.encode("ascii"))
+    # subprocess arguments can also be pathlib.Path instances (PurePath is the
+    # base class for all platform-specific Path classes). We never put the
+    # token in a path so there's nothing to do here
+    elif isinstance(value, PurePath):
+        return value
     else:
-        raise ValueError(f"Got {type(value)} expected str or bytes")
+        raise ValueError(f"Got {type(value)} expected str, bytes or Path")


### PR DESCRIPTION
I suddenly remembered while putting a child down for a nap that
subprocess arguments can be Path instances as well as str/bytes. Thanks
brain!

This isn't actually necessary at the moment because our `subprocess.run`
wrapper (created to work around Windows compatibility issues in Python
<3.8) converts Paths to str anyway. But hopefully we'll remove the wrapper
at some point in which case we'll need to handle Paths correctly.