### PR TITLE
Make connection caching threadsafe

### DIFF
--- a/jobrunner/database.py
+++ b/jobrunner/database.py
@@ -10,12 +10,15 @@ shouldn't be too large a job.
 """
 import dataclasses
 from enum import Enum
-import functools
 import json
 from pathlib import Path
 import sqlite3
+import threading
 
 from . import config
+
+
+CONNECTION_CACHE = threading.local()
 
 
 def insert(item):
@@ -90,14 +93,22 @@ def transaction():
 
 
 def get_connection():
-    return get_connection_from_file(config.DATABASE_FILE)
+    # The caching below means we get the same connection to the database every
+    # time which is done not so much for efficiency as so that we can easily
+    # implement transaction support without having to explicitly pass round a
+    # connection object. This is done on a per-thread basis to avoid potential
+    # threading issues.
+    filename = config.DATABASE_FILE
+    # Looks icky but is documented `threading.local` usage
+    cache = CONNECTION_CACHE.__dict__
+    if filename in cache:
+        return cache[filename]
+    else:
+        connection = get_connection_from_file(filename)
+        cache[filename] = connection
+        return connection
 
 
-# LRU cache means we get the same connection to the database every time which
-# is done not so much for efficiency as so that we can easily implement
-# transaction support without having to explicitly pass round a connection
-# object.
-@functools.lru_cache()
 def get_connection_from_file(filename):
     if filename != ":memory:":
         filename.parent.mkdir(parents=True, exist_ok=True)

--- a/jobrunner/database.py
+++ b/jobrunner/database.py
@@ -110,7 +110,9 @@ def get_connection():
 
 
 def get_connection_from_file(filename):
-    if filename != ":memory:":
+    if str(filename).startswith(":memory:"):
+        filename = ":memory:"
+    else:
         filename.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(filename)
     # Enable autocommit so changes made outside of a transaction still get

--- a/jobrunner/local_run.py
+++ b/jobrunner/local_run.py
@@ -120,7 +120,10 @@ def create_and_run_jobs(
     docker.LABEL = docker_label
     config.LOCAL_RUN_MODE = True
     config.HIGH_PRIVACY_WORKSPACES_DIR = project_dir.parent
-    config.DATABASE_FILE = ":memory:"
+    # Append a random value so that multiple runs in the same process will each
+    # get their own unique in-memory database. This is only really relevant
+    # during testing.
+    config.DATABASE_FILE = f":memory:{random.randrange(sys.maxsize)}"
     config.JOB_LOG_DIR = temp_log_dir
     config.BACKEND = "expectations"
     config.USING_DUMMY_DATA_BACKEND = True


### PR DESCRIPTION
In the near future we plan to run the `sync` service in a thread
alongside the `run` service (for operational simplicity) and so we want
to make sure they don't attempt to share database connections.

We also make the in-memory database unique for each call to `local_run`
which simplifies testing.