### PR TITLE
feat: refactor logging setup and formatting

### DIFF
--- a/jobrunner/local_run.py
+++ b/jobrunner/local_run.py
@@ -50,7 +50,8 @@ from .string_utils import tabulate
 
 # First paragraph of docstring
 DESCRIPTION = __doc__.partition("\n\n")[0]
-
+# local run logging format
+LOCAL_RUN_FORMAT = "{action}{message}"
 
 def add_arguments(parser):
     parser.add_argument("actions", nargs="*", help="Name of project action to run")
@@ -200,9 +201,7 @@ def create_and_run_jobs(
     print(f"\nRunning actions: {', '.join(action_names)}\n")
 
     configure_logging(
-        # We don't need the full job ID in the log output here, it only clutters
-        # things
-        show_action_name_only=True,
+        fmt=LOCAL_RUN_FORMAT,
         # None of these status messages are particularly useful in local run
         # mode, and they can generate a lot of clutter in large dependency
         # trees
@@ -213,7 +212,7 @@ def create_and_run_jobs(
         ],
         # All the other output we produce goes to stdout and it's a bit
         # confusing if the log messages end up on a separate stream
-        log_to_stdout=True,
+        stream=sys.stdout,
     )
 
     # Run everything

--- a/jobrunner/models.py
+++ b/jobrunner/models.py
@@ -142,13 +142,20 @@ class Job:
     # On Python 3.8 we could use `functools.cached_property` here and avoid
     # recomputing this every time
     @property
+    def project(self):
+        """Project name based on github url."""
+        return project_name_from_url(self.repo_url)
+
+    # On Python 3.8 we could use `functools.cached_property` here and avoid
+    # recomputing this every time
+    @property
     def slug(self):
         """
         Use a human-readable slug rather than just an opaque ID to identify jobs in
         order to make debugging easier
         """
         return slugify(
-            f"{project_name_from_url(self.repo_url)}-{self.action}-{self.id}"
+            f"{self.project}-{self.action}-{self.id}"
         )
 
     @staticmethod

--- a/jobrunner/service.py
+++ b/jobrunner/service.py
@@ -24,6 +24,7 @@ log = logging.getLogger(__name__)
 
 def main():
     """Run the main run loop after starting the sync loop in a thread."""
+    # extra space to align with other thread's "sync" label.
     threading.current_thread().name = "run "
     fmt = "{asctime} {threadName} {message} {tags}"
     configure_logging(fmt)

--- a/jobrunner/service.py
+++ b/jobrunner/service.py
@@ -24,6 +24,9 @@ log = logging.getLogger(__name__)
 
 def main():
     """Run the main run loop after starting the sync loop in a thread."""
+    threading.current_thread().name = "run "
+    fmt = "{asctime} {threadName} {message} {tags}"
+    configure_logging(fmt)
 
     # load any env file
     path = Path(os.environ.get("ENVPATH", ".env"))
@@ -38,6 +41,7 @@ def main():
         # daemon=True means this thread will be automatically join()ed when the
         # process exits
         thread = threading.Thread(target=sync_wrapper, daemon=True)
+        thread.name = 'sync'
         thread.start()
         run.main()
     except KeyboardInterrupt:
@@ -62,5 +66,4 @@ def parse_env(contents):
 
 
 if __name__ == "__main__":
-    configure_logging()
     main()

--- a/tests/test_log_utils.py
+++ b/tests/test_log_utils.py
@@ -1,0 +1,71 @@
+from datetime import datetime
+import logging
+import time
+
+import pytest
+
+from jobrunner.models import Job, JobRequest
+from jobrunner import log_utils, local_run
+
+
+FROZEN_TIMESTAMP = 1608568119.1467905
+FROZEN_TIMESTRING = datetime.utcfromtimestamp(FROZEN_TIMESTAMP).isoformat()
+
+repo_url='https://github.com/opensafely/project'
+test_job = Job(id='id', action='action', repo_url=repo_url)
+test_request = JobRequest(
+    id='request',
+    repo_url=repo_url,
+    workspace="workspace",
+    commit='commit',
+    requested_actions=['action'],
+    database_name='dummy',
+)
+
+
+def test_formatting_filter():
+    record = logging.makeLogRecord({})
+    assert log_utils.formatting_filter(record)
+    assert record.action == ""
+
+    record = logging.makeLogRecord({"job": test_job})
+    assert log_utils.formatting_filter(record)
+    assert record.action == "action: "
+    assert record.tags == "project=project action=action id=id"
+
+    record = logging.makeLogRecord({"job": test_job, "status_code": "code"})
+    assert log_utils.formatting_filter(record)
+    assert record.tags == "status=code project=project action=action id=id"
+
+    record = logging.makeLogRecord({"job": test_job, "job_request": test_request})
+    assert log_utils.formatting_filter(record)
+    assert record.tags == "project=project action=action id=id req=request"
+
+
+def test_jobrunner_formatter_default(monkeypatch):
+    monkeypatch.setattr(time, 'time', lambda: FROZEN_TIMESTAMP)
+    record = logging.makeLogRecord({
+        "msg": "message",
+        "job": test_job,
+        "job_request": test_request,
+        "status_code": "status",
+    })
+    log_utils.formatting_filter(record)
+    formatter = log_utils.JobRunnerFormatter(log_utils.DEFAULT_FORMAT, style='{')
+    assert formatter.format(record) == (
+        "2020-12-21 16:28:39.146Z message "
+        "status=status project=project action=action id=id req=request"
+    )
+
+
+def test_jobrunner_formatter_local_run(monkeypatch):
+    monkeypatch.setattr(time, 'time', lambda: FROZEN_TIMESTAMP)
+    record = logging.makeLogRecord({
+        "msg": "message",
+        "job": test_job,
+        "job_request": test_request,
+        "status_code": "status",
+    })
+    log_utils.formatting_filter(record)
+    formatter = log_utils.JobRunnerFormatter(local_run.LOCAL_RUN_FORMAT, style='{')
+    assert formatter.format(record) == "action: message"


### PR DESCRIPTION
Move the formatting logic into a filter rather than the formatter. This avoids
the need for parameterising the formatter, it can be customised just using a
regular format string, which I then used in the 2 places that need it
(local_run and threaded service).

Additionally, changed the log format to put various tags at the end of the
output. This pushes line noise out to the right, but still allows us to filter,
e.g:

    grep project=foo log.txt | grep status=bar