### PR TITLE
Switch to Token Auth

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,8 +13,7 @@ services:
       # The backend requests which we should monitor
       - BACKEND=${OPENSAFELY_BACKEND}
       # Credentials for acessing the job server
-      - QUEUE_USER=${OPENSAFELY_QUEUE_USER}
-      - QUEUE_PASS=${OPENSAFELY_QUEUE_PASS}
+      - JOB_SERVER_TOKEN=${OPENSAFELY_JOB_SERVER_TOKEN}
       # Working directory (see the volume mounts below)
       - WORK_DIR=/work_dir
       # A location where outputs should be stored

--- a/dotenv-sample
+++ b/dotenv-sample
@@ -1,12 +1,11 @@
 # The name of this backend
 OPENSAFELY_BACKEND=tpp
 
-# Credentials for logging into the job server
-OPENSAFELY_QUEUE_USER=user
-OPENSAFELY_QUEUE_PASS=pass
-
 # The endpoint to poll for jobs
 OPENSAFELY_JOB_SERVER_ENDPOINT=https://jobs.opensafely.org/jobs/
+
+# Credentials for logging into the job server
+OPENSAFELY_JOB_SERVER_TOKEN=pass
 
 # A location where cohort CSVs (one row per patient) should be
 # stored. This folder must exist.

--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -28,8 +28,7 @@ JOB_LOG_DIR = HIGH_PRIVACY_STORAGE_BASE / "logs"
 JOB_SERVER_ENDPOINT = os.environ.get(
     "JOB_SERVER_ENDPOINT", "https://jobs.opensafely.org/api/v2/"
 )
-QUEUE_USER = os.environ.get("QUEUE_USER", "user")
-QUEUE_PASS = os.environ.get("QUEUE_PASS", "pass")
+JOB_SERVER_TOKEN = os.environ.get("JOB_SERVER_TOKEN", "token")
 
 PRIVATE_REPO_ACCESS_TOKEN = os.environ.get("PRIVATE_REPO_ACCESS_TOKEN", "")
 

--- a/jobrunner/sync.py
+++ b/jobrunner/sync.py
@@ -65,7 +65,7 @@ def api_request(method, path, *args, **kwargs):
     url = "{}/{}/".format(config.JOB_SERVER_ENDPOINT.rstrip("/"), path.strip("/"))
     # We could do this just once on import, but it makes changing the config in
     # tests more fiddly
-    session.auth = (config.QUEUE_USER, config.QUEUE_PASS)
+    session.headers = {"Authorization": config.JOB_SERVER_TOKEN}
     response = session.request(method, url, *args, **kwargs)
 
     log.debug(


### PR DESCRIPTION
Use a token in the `Authorization` HTTP header for authentication with job-server.

This is the job-runner side of opensafely/job-server#303.