### PR TITLE
fix: Correctly extract project names from Windows paths

### DIFF
--- a/jobrunner/string_utils.py
+++ b/jobrunner/string_utils.py
@@ -16,6 +16,10 @@ def project_name_from_url(url):
     significant about a repository's name but it can make debugging easier to
     include it in various places)
     """
+    # "URL" here can in fact be a local path and it may be a Windows path, in
+    # which case we need to convert the slash type so that it gets handled
+    # correctly
+    url = url.replace("\\", "/")
     name = urlparse(url).path.strip("/").split("/")[-1]
     if name.endswith(".git"):
         name = name[:-4]

--- a/tests/test_string_utils.py
+++ b/tests/test_string_utils.py
@@ -1,0 +1,8 @@
+from jobrunner.string_utils import project_name_from_url
+
+
+def test_project_name_from_url():
+    assert project_name_from_url("https://github.com/opensafely/test1.git") == "test1"
+    assert project_name_from_url("https://github.com/opensafely/test2/") == "test2"
+    assert project_name_from_url("/some/local/path/test3/") == "test3"
+    assert project_name_from_url("C:\\some\\windows\\path\\test4\\") == "test4"


### PR DESCRIPTION
Because we weren't doing this correctly before a project with a long
local path would end up with correspondingly long job slug e.g.

    C:\Users\Dave\Documents\Foo\Bar\Baz\Blah

Would become

    job-usersdavedocumentsfoobarbazblah

As log files produced during local run contain the job slug, this made
it much more likely that we would exceed Windows 260 character path name
limit.

This change doesn't fix the path limit problem, but it does mean we
probably don't need to worry about it for now.