### PR TITLE
feat: refactor environment variable loading

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,31 +6,6 @@ services:
     image: ghcr.io/opensafely/job-runner:latest
     init: true
     restart: unless-stopped
-    environment:
-      &jobrunner_environment
-      # The job server endpoint
-      - JOB_SERVER_ENDPOINT=${OPENSAFELY_JOB_SERVER_ENDPOINT}
-      # The backend requests which we should monitor
-      - BACKEND=${OPENSAFELY_BACKEND}
-      # Credentials for acessing the job server
-      - JOB_SERVER_TOKEN=${OPENSAFELY_JOB_SERVER_TOKEN}
-      # Working directory (see the volume mounts below)
-      - WORK_DIR=/work_dir
-      # A location where outputs should be stored
-      - HIGH_PRIVACY_STORAGE_BASE=${OPENSAFELY_HIGH_PRIVACY_STORAGE_BASE}
-      - MEDIUM_PRIVACY_STORAGE_BASE=${OPENSAFELY_MEDIUM_PRIVACY_STORAGE_BASE}
-      # A Github developer access key which can read private repos
-      - PRIVATE_REPO_ACCESS_TOKEN=${OPENSAFELY_PRIVATE_REPO_ACCESS_TOKEN}
-      # Database URLs
-      - FULL_DATABASE_URL=${OPENSAFELY_FULL_DATABASE_URL}
-      - SLICE_DATABASE_URL=${OPENSAFELY_SLICE_DATABASE_URL}
-      - DUMMY_DATABASE_URL=${OPENSAFELY_DUMMY_DATABASE_URL}
-      - TEMP_DATABASE_NAME=${OPENSAFELY_TEMP_DATABASE_NAME}
-      # Polling
-      - POLL_INTERVAL=${OPENSAFELY_POLL_INTERVAL}
-      - JOB_LOOP_INTERVAL=${OPENSAFELY_JOB_LOOP_INTERVAL}
-      # Parallelism
-      - MAX_WORKERS=${OPENSAFELY_MAX_WORKERS}
     volumes:
       &jobrunner_volumes
       - type: bind
@@ -51,8 +26,7 @@ services:
     image: ghcr.io/opensafely/job-runner:latest
     init: true
     restart: unless-stopped
-    # Re-use environment and volume config from above
-    environment: *jobrunner_environment
+    # Re-use volume config from above
     volumes: *jobrunner_volumes
     command: python -m jobrunner.sync
 

--- a/jobrunner/__init__.py
+++ b/jobrunner/__init__.py
@@ -1,0 +1,50 @@
+"""Handle env file loading an parsing as early as possible."""
+from pathlib import Path
+import logging
+import os
+
+EARLY_LOGS = []
+
+
+def parse_env(contents):
+    """Parse a simple environment file."""
+    env = {}
+    for line in contents.split("\n"):
+        line = line.strip()
+        if not line or line[0] == "#":
+            continue
+        k, _, v = line.partition("=")
+        env[k.strip()] = v.strip().strip('"').strip("'")
+    return env
+
+
+def load_env(path=None, logs=EARLY_LOGS):
+    if not path.exists():
+        logs.append(
+            (
+                logging.WARNING,
+                f"Could not find environment file {path}",
+            )
+        )
+        return
+
+    env = parse_env(path.read_text())
+    if env:
+        os.environ.update(env)
+        logs.append(
+            (
+                logging.INFO,
+                f"Loaded environment variables from {path}",
+            )
+        )
+    else:
+        logs.append(
+            (
+                logging.WARNING,
+                f"Could not parse environment variables from {path}",
+            )
+        )
+
+
+# load any env file *before* we import anything
+load_env(Path(os.environ.get("ENVPATH", ".env")))

--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -3,9 +3,19 @@ from pathlib import Path
 from multiprocessing import cpu_count
 
 
+def getenv(name, default=None, env=os.environ):
+    value = env.get(name)
+    if value is None:
+        value = env.get("OPENSAFELY_" + name)
+    if value is None:
+        return default
+    else:
+        return value
+
+
 default_work_dir = Path(__file__) / "../../workdir"
 
-WORK_DIR = Path(os.environ.get("WORK_DIR", default_work_dir)).resolve()
+WORK_DIR = Path(getenv("WORK_DIR", default_work_dir)).resolve()
 
 TMP_DIR = WORK_DIR / "temp"
 
@@ -14,10 +24,10 @@ GIT_REPO_DIR = WORK_DIR / "repos"
 DATABASE_FILE = WORK_DIR / "db.sqlite"
 
 HIGH_PRIVACY_STORAGE_BASE = Path(
-    os.environ.get("HIGH_PRIVACY_STORAGE_BASE", WORK_DIR / "high_privacy")
+    getenv("HIGH_PRIVACY_STORAGE_BASE", WORK_DIR / "high_privacy")
 )
 MEDIUM_PRIVACY_STORAGE_BASE = Path(
-    os.environ.get("MEDIUM_PRIVACY_STORAGE_BASE", WORK_DIR / "medium_privacy")
+    getenv("MEDIUM_PRIVACY_STORAGE_BASE", WORK_DIR / "medium_privacy")
 )
 
 HIGH_PRIVACY_WORKSPACES_DIR = HIGH_PRIVACY_STORAGE_BASE / "workspaces"
@@ -25,17 +35,20 @@ MEDIUM_PRIVACY_WORKSPACES_DIR = MEDIUM_PRIVACY_STORAGE_BASE / "workspaces"
 
 JOB_LOG_DIR = HIGH_PRIVACY_STORAGE_BASE / "logs"
 
-JOB_SERVER_ENDPOINT = os.environ.get(
+JOB_SERVER_ENDPOINT = getenv(
     "JOB_SERVER_ENDPOINT", "https://jobs.opensafely.org/api/v2/"
 )
-JOB_SERVER_TOKEN = os.environ.get("JOB_SERVER_TOKEN", "token")
+JOB_SERVER_TOKEN = getenv("JOB_SERVER_TOKEN", "token")
 
-PRIVATE_REPO_ACCESS_TOKEN = os.environ.get("PRIVATE_REPO_ACCESS_TOKEN", "")
+QUEUE_USER = getenv("QUEUE_USER", "user")
+QUEUE_PASS = getenv("QUEUE_PASS", "pass")
 
-POLL_INTERVAL = float(os.environ.get("POLL_INTERVAL", "5"))
-JOB_LOOP_INTERVAL = float(os.environ.get("JOB_LOOP_INTERVAL", "1.0"))
+PRIVATE_REPO_ACCESS_TOKEN = getenv("PRIVATE_REPO_ACCESS_TOKEN", "")
 
-BACKEND = os.environ.get("BACKEND", "expectations")
+POLL_INTERVAL = float(getenv("POLL_INTERVAL", "5"))
+JOB_LOOP_INTERVAL = float(getenv("JOB_LOOP_INTERVAL", "1.0"))
+
+BACKEND = getenv("BACKEND", "expectations")
 
 USING_DUMMY_DATA_BACKEND = BACKEND == "expectations"
 
@@ -44,23 +57,23 @@ ALLOWED_IMAGES = {"cohortextractor", "stata-mp", "r", "jupyter", "python"}
 DOCKER_REGISTRY = "ghcr.io/opensafely"
 
 DATABASE_URLS = {
-    "full": os.environ.get("FULL_DATABASE_URL"),
-    "slice": os.environ.get("SLICE_DATABASE_URL"),
-    "dummy": os.environ.get("DUMMY_DATABASE_URL"),
+    "full": getenv("FULL_DATABASE_URL"),
+    "slice": getenv("SLICE_DATABASE_URL"),
+    "dummy": getenv("DUMMY_DATABASE_URL"),
 }
 
-TEMP_DATABASE_NAME = os.environ.get("TEMP_DATABASE_NAME")
+TEMP_DATABASE_NAME = getenv("TEMP_DATABASE_NAME")
 
-MAX_WORKERS = int(os.environ.get("MAX_WORKERS") or max(cpu_count() - 1, 1))
+MAX_WORKERS = int(getenv("MAX_WORKERS") or max(cpu_count() - 1, 1))
 
 # See `local_run.py` for more detail
 LOCAL_RUN_MODE = False
 
 # See `manage_jobs.ensure_overwritable` for more detail
-ENABLE_PERMISSIONS_WORKAROUND = bool(os.environ.get("ENABLE_PERMISSIONS_WORKAROUND"))
+ENABLE_PERMISSIONS_WORKAROUND = bool(getenv("ENABLE_PERMISSIONS_WORKAROUND"))
 
-STATA_LICENSE = os.environ.get("STATA_LICENCE")
-STATA_LICENSE_REPO = os.environ.get(
+STATA_LICENSE = getenv("STATA_LICENCE")
+STATA_LICENSE_REPO = getenv(
     "STATA_LICENCE_REPO",
     "https://github.com/opensafely/server-instructions.git",
 )

--- a/jobrunner/log_utils.py
+++ b/jobrunner/log_utils.py
@@ -14,6 +14,7 @@ import sys
 import threading
 import time
 
+import jobrunner
 
 DEFAULT_FORMAT = "{asctime} {message} {tags}"
 
@@ -56,6 +57,9 @@ def configure_logging(fmt=DEFAULT_FORMAT, stream=None, status_codes_to_ignore=No
     handler.addFilter(formatting_filter)
     logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO"), handlers=[handler])
     sys.excepthook = show_subprocess_stderr
+    log = logging.getLogger()
+    for args in jobrunner.EARLY_LOGS:
+        log.log(*args)
 
 
 class JobRunnerFormatter(logging.Formatter):

--- a/jobrunner/service.py
+++ b/jobrunner/service.py
@@ -9,37 +9,16 @@ import sys
 import time
 import threading
 
-log = logging.getLogger(__name__)
-
 # temp workaround for not having PYTHONPATH in the service config
 sys.path.insert(0, "./lib")
-
-# load any env file *before* we import config module
-# TODO: we should probably have a wrapper that does this before python is
-# loaded, or make config reloadable.
-def parse_env(contents):
-    """Parse a simple environment file."""
-    env = {}
-    for line in contents.split("\n"):
-        line = line.strip()
-        if not line or line[0] == "#":
-            continue
-        k, _, v = line.partition("=")
-        env[k.strip()] = v.strip().strip('"').strip("'")
-    return env
-
-
-path = Path(os.environ.get("ENVPATH", ".env"))
-if path.exists():
-    log.info(f"Loading environment variables from {path}")
-    env = parse_env(path.read_text())
-    if env:
-        os.environ.update(env)
 
 from . import config
 from .log_utils import configure_logging
 from . import run
 from . import sync
+
+
+log = logging.getLogger(__name__)
 
 
 def main():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,14 @@ import subprocess
 
 import pytest
 
+import jobrunner.config
+
+
+# set up default test config to ensure test run expectations
+# otherwise the current .env values are used
+jobrunner.config.BACKEND = "expectations"
+jobrunner.config.USING_DUMMY_DATA_BACKEND = True
+
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow_test: mark test as being slow running")

--- a/tests/test_jobrunner.py
+++ b/tests/test_jobrunner.py
@@ -1,0 +1,42 @@
+from textwrap import dedent
+import logging
+from pathlib import Path
+
+import jobrunner
+
+
+def test_parse_env():
+    env = jobrunner.parse_env(
+        dedent(
+            """\
+        key=value
+        spaces_value=val ue
+        spaces key = value
+           whitespace\t  =  value  
+        single='val ue'
+        double="val ue"
+    """
+        )
+    )
+    assert env == {
+        "key": "value",
+        "spaces_value": "val ue",
+        "spaces key": "value",
+        "whitespace": "value",
+        "single": "val ue",
+        "double": "val ue",
+    }
+
+
+def test_load_env(tmp_path):
+    logs = []
+    jobrunner.load_env(Path("doesnotexist"), logs)
+    assert logs == [(logging.WARNING, "Could not find environment file doesnotexist")]
+
+    logs = []
+    empty = tmp_path / "empty"
+    empty.write_text("")
+    jobrunner.load_env(empty, logs)
+    assert logs == [
+        (logging.WARNING, f"Could not parse environment variables from {empty}")
+    ]

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -21,26 +21,3 @@ def test_service_main():
     p.send_signal(signal.SIGINT)
     p.wait()
     assert p.returncode == 0
-
-
-def test_parse_env():
-    env = service.parse_env(
-        dedent(
-            """\
-        key=value
-        spaces_value=val ue
-        spaces key = value
-           whitespace\t  =  value  
-        single='val ue'
-        double="val ue"
-    """
-        )
-    )
-    assert env == {
-        "key": "value",
-        "spaces_value": "val ue",
-        "spaces key": "value",
-        "whitespace": "value",
-        "single": "val ue",
-        "double": "val ue",
-    }


### PR DESCRIPTION
1. Environment files are now loaded via `jobrunner/__init__.py`, which
ensures they are done early before the config module is imported.

2. Environment variables can be with or without their OPENSAFELY_
prefix. Previously we relied on docker-compose's .env parsing and
mapping the OPENSAFELY_ version to the plain version. This new way works
for both docker-compose and other methods (i.e. windows service).

3. Given a local .env file is parsed on import now, some test
configuration was needed to ensure correct config values for the tests to
run.