### PR TITLE
fix: make windows service use a bash runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ pip-wheel-metadata/*
 /lib
 /tests/fixtures/*/output/*
 /tests/fixtures/*/metadata
+service*.log

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,31 +6,6 @@ services:
     image: ghcr.io/opensafely/job-runner:latest
     init: true
     restart: unless-stopped
-    environment:
-      &jobrunner_environment
-      # The job server endpoint
-      - JOB_SERVER_ENDPOINT=${OPENSAFELY_JOB_SERVER_ENDPOINT}
-      # The backend requests which we should monitor
-      - BACKEND=${OPENSAFELY_BACKEND}
-      # Credentials for acessing the job server
-      - JOB_SERVER_TOKEN=${OPENSAFELY_JOB_SERVER_TOKEN}
-      # Working directory (see the volume mounts below)
-      - WORK_DIR=/work_dir
-      # A location where outputs should be stored
-      - HIGH_PRIVACY_STORAGE_BASE=${OPENSAFELY_HIGH_PRIVACY_STORAGE_BASE}
-      - MEDIUM_PRIVACY_STORAGE_BASE=${OPENSAFELY_MEDIUM_PRIVACY_STORAGE_BASE}
-      # A Github developer access key which can read private repos
-      - PRIVATE_REPO_ACCESS_TOKEN=${OPENSAFELY_PRIVATE_REPO_ACCESS_TOKEN}
-      # Database URLs
-      - FULL_DATABASE_URL=${OPENSAFELY_FULL_DATABASE_URL}
-      - SLICE_DATABASE_URL=${OPENSAFELY_SLICE_DATABASE_URL}
-      - DUMMY_DATABASE_URL=${OPENSAFELY_DUMMY_DATABASE_URL}
-      - TEMP_DATABASE_NAME=${OPENSAFELY_TEMP_DATABASE_NAME}
-      # Polling
-      - POLL_INTERVAL=${OPENSAFELY_POLL_INTERVAL}
-      - JOB_LOOP_INTERVAL=${OPENSAFELY_JOB_LOOP_INTERVAL}
-      # Parallelism
-      - MAX_WORKERS=${OPENSAFELY_MAX_WORKERS}
     volumes:
       &jobrunner_volumes
       - type: bind
@@ -52,7 +27,6 @@ services:
     init: true
     restart: unless-stopped
     # Re-use environment and volume config from above
-    environment: *jobrunner_environment
     volumes: *jobrunner_volumes
     command: python -m jobrunner.sync
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,14 +6,19 @@ services:
     image: ghcr.io/opensafely/job-runner:latest
     init: true
     restart: unless-stopped
+    env_file: .env
+    environment:
+      &jobrunner_environment
+      # Working directory (see the volume mounts below)
+      - WORK_DIR=/work_dir
     volumes:
       &jobrunner_volumes
       - type: bind
-        source: ${OPENSAFELY_MEDIUM_PRIVACY_STORAGE_BASE}
-        target: ${OPENSAFELY_MEDIUM_PRIVACY_STORAGE_BASE}
+        source: ${MEDIUM_PRIVACY_STORAGE_BASE}
+        target: ${MEDIUM_PRIVACY_STORAGE_BASE}
       - type: bind
-        source: ${OPENSAFELY_HIGH_PRIVACY_STORAGE_BASE}
-        target: ${OPENSAFELY_HIGH_PRIVACY_STORAGE_BASE}
+        source: ${HIGH_PRIVACY_STORAGE_BASE}
+        target: ${HIGH_PRIVACY_STORAGE_BASE}
       - type: bind
         source: //var/run/docker.sock
         target: /var/run/docker.sock
@@ -27,6 +32,8 @@ services:
     init: true
     restart: unless-stopped
     # Re-use environment and volume config from above
+    env_file: .env
+    environment: *jobrunner_environment
     volumes: *jobrunner_volumes
     command: python -m jobrunner.sync
 

--- a/dotenv-sample
+++ b/dotenv-sample
@@ -1,47 +1,47 @@
 # The name of this backend
-OPENSAFELY_BACKEND=tpp
+BACKEND=tpp
 
 # The endpoint to poll for jobs
-OPENSAFELY_JOB_SERVER_ENDPOINT=https://jobs.opensafely.org/jobs/
+JOB_SERVER_ENDPOINT=https://jobs.opensafely.org/jobs/
 
 # Credentials for logging into the job server
-OPENSAFELY_JOB_SERVER_TOKEN=pass
+JOB_SERVER_TOKEN=pass
 
 # A location where cohort CSVs (one row per patient) should be
 # stored. This folder must exist.
-OPENSAFELY_HIGH_PRIVACY_STORAGE_BASE=/home/opensafely/high_security
+HIGH_PRIVACY_STORAGE_BASE=/home/opensafely/high_security
 # Or in Windows:
-# OPENSAFELY_HIGH_PRIVACY_STORAGE_BASE=/e/Users/opensafely/high_security
+# HIGH_PRIVACY_STORAGE_BASE=/e/Users/opensafely/high_security
 
 # A location where script outputs (some for publication) should be
 # stored
-OPENSAFELY_MEDIUM_PRIVACY_STORAGE_BASE=/tmp/outputs/medium_security
+MEDIUM_PRIVACY_STORAGE_BASE=/tmp/outputs/medium_security
 
 # A Github developer token that has read access to private repos
-OPENSAFELY_PRIVATE_REPO_ACCESS_TOKEN=xxxx
+PRIVATE_REPO_ACCESS_TOKEN=xxxx
 
 # A database containing dummy data; results from this could be freely
 # published without review
-OPENSAFELY_DUMMY_DATABASE_URL=mssql+pyodbc://xxxx
+DUMMY_DATABASE_URL=mssql+pyodbc://xxxx
 
 # A database containing a slice of the full data; useful for checking
 # or debuggin real data without potentially having to wait for hours
 # for completion
-OPENSAFELY_SLICE_DATABASE_URL=mssql+pyodbc://xxxx
+SLICE_DATABASE_URL=mssql+pyodbc://xxxx
 
 # The full database
-OPENSAFELY_FULL_DATABASE_URL=mssql+pyodbc://xxxx
+FULL_DATABASE_URL=mssql+pyodbc://xxxx
 
 # Database in which we can create temporary tables
-OPENSAFELY_TEMP_DATABASE_NAME=OPENCoronaTempTables
+TEMP_DATABASE_NAME=OPENCoronaTempTables
 
 # How frequently to poll the job-server to pick up new JobRequests and post
 # updates to Jobs
-OPENSAFELY_POLL_INTERVAL=5
+POLL_INTERVAL=5
 
 # How frequently to poll internal database and Docker for the current state of
 # active jobs
-OPENSAFELY_JOB_LOOP_INTERVAL=1.0
+JOB_LOOP_INTERVAL=1.0
 
 # Default is number of CPUs minus one. Change this to reduce parallelism
-OPENSAFELY_MAX_WORKERS=
+MAX_WORKERS=

--- a/jobrunner/service.py
+++ b/jobrunner/service.py
@@ -9,37 +9,14 @@ import sys
 import time
 import threading
 
-log = logging.getLogger(__name__)
-
-# temp workaround for not having PYTHONPATH in the service config
-sys.path.insert(0, "./lib")
-
-# load any env file *before* we import config module
-# TODO: we should probably have a wrapper that does this before python is
-# loaded, or make config reloadable.
-def parse_env(contents):
-    """Parse a simple environment file."""
-    env = {}
-    for line in contents.split("\n"):
-        line = line.strip()
-        if not line or line[0] == "#":
-            continue
-        k, _, v = line.partition("=")
-        env[k.strip()] = v.strip().strip('"').strip("'")
-    return env
-
-
-path = Path(os.environ.get("ENVPATH", ".env"))
-if path.exists():
-    log.info(f"Loading environment variables from {path}")
-    env = parse_env(path.read_text())
-    if env:
-        os.environ.update(env)
 
 from . import config
 from .log_utils import configure_logging
 from . import run
 from . import sync
+
+
+log = logging.getLogger(__name__)
 
 
 def main():

--- a/scripts/install.bat
+++ b/scripts/install.bat
@@ -1,20 +1,22 @@
 REM usage: install.bat USER PASSWORD
-nssm install opensafely "C:\Program Files\Python39\python" -m jobrunner.service
-nssm set opensafely AppDirectory E:\job-runner
+REM installs/configures the opensafely service
+set directory="E:\job-runner"
+nssm stop opensafely
+nssm remove opensafely confirm
+nssm install opensafely "C:\Program Files\Git\usr\bin\bash" "%directory%\scripts\run.sh"
+nssm set opensafely AppDirectory %directory%
 nssm set opensafely DisplayName "OpenSAFELY job runner"
 nssm set opensafely Start SERVICE_AUTO_START
-REM Note: use AppEnvironmentExtra to avoid any potential conflicts with registry based AppEnvironment key
-nssm set opeensafely AppEnvironmentExtra PYTHONPATH=lib
 REM login as user
-nssm set opensafely ObjectName %1% %2%
+nssm set opensafely ObjectName %1 %2
 nssm set opensafely DependOnService com.docker.service
 nssm set opensafely AppThrottle 10000
 nssm set opensafely AppExit Default Restart
 nssm set opensafely AppRestartDelay 1000
-# don't send WM_CLOSE or WM_QUIT, but do send Ctrl-C and TerminateProcess
+REM don't send WM_CLOSE or WM_QUIT, but do send Ctrl-C and TerminateProcess
 nssm set opensafely AppStopMethodSkip 6
-nssm set opensafely AppStdout E:\job-runner\service.log
-nssm set opensafely AppStderr E:\job-runner\service.err.log
+nssm set opensafely AppStdout %directory%\service.log
+nssm set opensafely AppStderr %directory%\service.err.log
 nssm set opensafely AppStdoutCreationDisposition 4
 nssm set opensafely AppStderrCreationDisposition 4
 nssm set opensafely AppRotateFiles 1

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,9 @@
+# no shebang as on windows
+#
+# assumes to be invoked in working dir of job-runner checkout
+# set -a means all declared variables are exported
+set -a
+source .env
+set +a
+export PYTHONPATH="lib"
+exec "C:\Program Files\Python39\python" -m jobrunner.service

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -21,26 +21,3 @@ def test_service_main():
     p.send_signal(signal.SIGINT)
     p.wait()
     assert p.returncode == 0
-
-
-def test_parse_env():
-    env = service.parse_env(
-        dedent(
-            """\
-        key=value
-        spaces_value=val ue
-        spaces key = value
-           whitespace\t  =  value  
-        single='val ue'
-        double="val ue"
-    """
-        )
-    )
-    assert env == {
-        "key": "value",
-        "spaces_value": "val ue",
-        "spaces key": "value",
-        "whitespace": "value",
-        "single": "val ue",
-        "double": "val ue",
-    }


### PR DESCRIPTION
This changes the nssm config to launch a bash script that sources .env
and then execs to python.

This means we do not need to do any env parsing in python, which is
good.

Also, we drop the OPENSAFELY_ prefix used by the current .env and
docker-compose tooling, just using the actual environment variables
directly.

NOTE: the .env file in prod will need updating to remove OPENSAFELY_ prefix when this is deployed.