### PR TITLE
ci: refactor windows install script to be less shoddy

### DIFF
--- a/scripts/install.bat
+++ b/scripts/install.bat
@@ -21,7 +21,7 @@ if %ERRORLEVEL% NEQ 0 (
 REM now we know the service definitely exists, configure it
 
 %nssm% set opensafely Application "C:\Program Files\Git\usr\bin\bash"
-%nssm% set opensafely AppParameters "%directory%\scripts\run.sh"
+%nssm% set opensafely AppParameters "%directory%\scripts\run.sh -m jobrunner.service"
 %nssm% set opensafely AppDirectory %directory%
 %nssm% set opensafely DisplayName "OpenSAFELY job runner"
 %nssm% set opensafely Start SERVICE_AUTO_START

--- a/scripts/install.bat
+++ b/scripts/install.bat
@@ -2,12 +2,15 @@
 REM This scripts installs/configures the opensafely service, designed to be
 REM installed on the opensafely TPP backend
 
+REM We make some assumtions about paths for the TPP backend
 set directory=E:\job-runner
 set nssm=C:\nssm-2.24\win64\nssm.exe
 
+REM we require both user name and a password to run, so check
 if "%1" == "" GOTO :usage
 if "%2" == "" GOTO :usage
 
+REM check the service is installed, and either stop it or install it.
 sc query opensafely | find "does not exist" >nul
 if %ERRORLEVEL% NEQ 0 ( 
   %nssm% stop opensafely
@@ -23,7 +26,7 @@ REM now we know the service definitely exists, configure it
 %nssm% set opensafely DisplayName "OpenSAFELY job runner"
 %nssm% set opensafely Start SERVICE_AUTO_START
 
-REM check docker exists, because $REASONS
+REM check docker service exists, because $REASONS
 sc query com.docker.service | find "does not exist" >nul
 if %ERRORLEVEL% NEQ 0 ( %nssm% set opensafely DependOnService com.docker.service )
 

--- a/scripts/install.bat
+++ b/scripts/install.bat
@@ -1,25 +1,52 @@
-REM usage: install.bat USER PASSWORD
-REM installs/configures the opensafely service
-set directory="E:\job-runner"
-nssm stop opensafely
-nssm remove opensafely confirm
-nssm install opensafely "C:\Program Files\Git\usr\bin\bash" "%directory%\scripts\run.sh"
-nssm set opensafely AppDirectory %directory%
-nssm set opensafely DisplayName "OpenSAFELY job runner"
-nssm set opensafely Start SERVICE_AUTO_START
-REM login as user
-nssm set opensafely ObjectName %1 %2
-nssm set opensafely DependOnService com.docker.service
-nssm set opensafely AppThrottle 10000
-nssm set opensafely AppExit Default Restart
-nssm set opensafely AppRestartDelay 1000
+@echo off
+REM This scripts installs/configures the opensafely service, designed to be
+REM installed on the opensafely TPP backend
+
+set directory=E:\job-runner
+set nssm=C:\nssm-2.24\win64\nssm.exe
+
+if "%1" == "" GOTO :usage
+if "%2" == "" GOTO :usage
+
+sc query opensafely | find "does not exist" >nul
+if %ERRORLEVEL% NEQ 0 ( 
+  %nssm% stop opensafely
+) else ( 
+  %nssm% install opensafely "C:\Program Files\Git\usr\bin\bash" 
+)
+
+REM now we know the service definitely exists, configure it
+
+%nssm% set opensafely Application "C:\Program Files\Git\usr\bin\bash"
+%nssm% set opensafely AppParameters "%directory%\scripts\run.sh"
+%nssm% set opensafely AppDirectory %directory%
+%nssm% set opensafely DisplayName "OpenSAFELY job runner"
+%nssm% set opensafely Start SERVICE_AUTO_START
+
+REM check docker exists, because $REASONS
+sc query com.docker.service | find "does not exist" >nul
+if %ERRORLEVEL% NEQ 0 ( %nssm% set opensafely DependOnService com.docker.service )
+
+%nssm% set opensafely ObjectName %1 %2
+%nssm% set opensafely AppThrottle 10000
+%nssm% set opensafely AppExit Default Restart
+%nssm% set opensafely AppRestartDelay 1000
 REM don't send WM_CLOSE or WM_QUIT, but do send Ctrl-C and TerminateProcess
-nssm set opensafely AppStopMethodSkip 6
-nssm set opensafely AppStdout %directory%\service.log
-nssm set opensafely AppStderr %directory%\service.err.log
-nssm set opensafely AppStdoutCreationDisposition 4
-nssm set opensafely AppStderrCreationDisposition 4
-nssm set opensafely AppRotateFiles 1
+%nssm% set opensafely AppStopMethodSkip 6
+%nssm% set opensafely AppStdout %directory%\service.log
+%nssm% set opensafely AppStderr %directory%\service.err.log
+%nssm% set opensafely AppStdoutCreationDisposition 4
+%nssm% set opensafely AppStderrCreationDisposition 4
+%nssm% set opensafely AppRotateFiles 1
 REM rotate after 1 day or 1Gb (AppRotateBytes is in kb)
-nssm set opensafely AppRotateSeconds 86400
-nssm set opensafely AppRotateBytes 1048576
+%nssm% set opensafely AppRotateSeconds 86400
+%nssm% set opensafely AppRotateBytes 1048576
+
+REM we are done, try start the service
+%nssm% start opensafely
+EXIT /B 0
+
+
+:usage
+echo usage: install.bat USER PASSWORD
+EXIT /B 1

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -6,4 +6,5 @@ set -a
 source .env
 set +a
 export PYTHONPATH="lib"
-exec "C:\Program Files\Python39\python" -m jobrunner.service
+export ENABLE_PERMISSIONS_WORKAROUND=1
+exec "C:\\Program Files\\Python39\\python" -m jobrunner.service

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -7,4 +7,4 @@ source .env
 set +a
 export PYTHONPATH="lib"
 export ENABLE_PERMISSIONS_WORKAROUND=1
-exec "C:\\Program Files\\Python39\\python" -m jobrunner.service
+exec "C:\\Program Files\\Python39\\python" "$@"


### PR DESCRIPTION
 - it no longer removes the service, as that breaks the security set up.
 - explicit path for nssm
 - better output, suitable for copy/pasting
 - better error handling