### PR TITLE
fix: Generate consistent job IDs

### DIFF
--- a/jobrunner/add_job.py
+++ b/jobrunner/add_job.py
@@ -3,10 +3,12 @@ Development utility for creating and submitting a JobRequest without having a
 job-server
 """
 import argparse
+import base64
 import dataclasses
 import pprint
 from pathlib import Path
 from urllib.parse import urlparse
+import secrets
 import textwrap
 
 from .log_utils import configure_logging
@@ -27,7 +29,7 @@ def main(
         repo_url = str(path).replace("\\", "/")
     job_request = job_request_from_remote_format(
         dict(
-            identifier=Job.new_id(),
+            identifier=random_id(),
             sha=commit,
             workspace=dict(name=workspace, repo=repo_url, branch=branch, db=database),
             requested_actions=actions,
@@ -51,6 +53,17 @@ def display_obj(obj):
     output = pprint.pformat(data)
     print(textwrap.indent(output, "  "))
     print()
+
+
+def random_id():
+    """
+    Return a random 16 character lowercase alphanumeric string
+
+    We used to use UUID4's but they are unnecessarily long for our purposes
+    (particularly the hex representation) and shorter IDs make debugging
+    and inspecting the job-runner a bit more ergonomic.
+    """
+    return base64.b32encode(secrets.token_bytes(10)).decode("ascii").lower()
 
 
 if __name__ == "__main__":

--- a/jobrunner/create_or_update_jobs.py
+++ b/jobrunner/create_or_update_jobs.py
@@ -180,7 +180,6 @@ def recursively_add_jobs(job_request, project, action, force_run_actions):
             wait_for_job_ids.append(required_job.id)
 
     job = Job(
-        id=Job.new_id(),
         job_request_id=job_request.id,
         state=State.PENDING,
         repo_url=job_request.repo_url,
@@ -251,7 +250,6 @@ def create_failed_job(job_request, exception):
         now = int(time.time())
         insert(
             Job(
-                id=Job.new_id(),
                 job_request_id=job_request.id,
                 state=state,
                 repo_url=job_request.repo_url,


### PR DESCRIPTION
Rather than randomly generating a job ID each time, we now use the hash
of the job request ID and the action name – which together are
guaranteed unique. This means even if we lose the entire job-runner
database while jobs are running we should be able to gracefully
recover because the same set of jobs with the same IDs should be
automatically recreated by the sync service.

Losing state like this still won't be _entirely_ unproblematic: in
particular, jobs which have already completed but are part of a job
request which is still active won't have their statuses correctly
reported. But it will at least avoid the problem of orphan jobs which
require a manual cleanup.