### PR TITLE
fix: Pass environment through when fetching license

### DIFF
--- a/jobrunner/local_run.py
+++ b/jobrunner/local_run.py
@@ -375,7 +375,7 @@ def get_stata_license(repo=config.STATA_LICENSE_REPO):
             cmd,
             cwd=cwd,
             capture_output=True,
-            env={"GIT_TERMINAL_PROMPT": "0"},
+            env=dict(os.environ, GIT_TERMINAL_PROMPT="0"),
         )
         return result.returncode == 0
 


### PR DESCRIPTION
Without this (at least on my particular Linux setup) git can't
authenticate with Github.