### PR TITLE
chore: Remove config value from wrapper script

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,10 +1,17 @@
-# no shebang as on windows
+# This is a wrapper script used to invoke the job-runner on Windows with the
+# environment set correctly. It's assumed to be run in the working dir of a
+# job-runner checkout with copies of all dependencies in a "lib" directory.
 #
-# assumes to be invoked in working dir of job-runner checkout
+# Usage example:
+#
+#   bash scripts/run.sh -m jobrunner.service
+#
+# Note: no shebang as designed to run on Windows
+
+
 # set -a means all declared variables are exported
 set -a
 source .env
 set +a
 export PYTHONPATH="lib"
-export ENABLE_PERMISSIONS_WORKAROUND=1
 exec "C:\\Program Files\\Python39\\python" "$@"


### PR DESCRIPTION
This value has now been added to the environment file where it belongs.
Because the docker-compose file uses variables with an `OPENSAFELY_`
prefix we can set the config value for the native runner but not the
docker version. But it wouldn't actually be a problem to have it enabled
in both environments anyway.