### PR TITLE
Log data being sent to job-server

### DIFF
--- a/jobrunner/sync.py
+++ b/jobrunner/sync.py
@@ -50,6 +50,10 @@ def sync():
     jobs = find_where(Job, job_request_id__in=job_request_ids)
     jobs_data = [job_to_remote_format(i) for i in jobs]
     log.debug(f"Syncing {len(jobs_data)} jobs back to job-server")
+
+    # log what we're trying to send to job-server
+    log.info(f"Sending jobs to server: {jobs_data}")
+
     api_post("jobs", json=jobs_data)
 
 


### PR DESCRIPTION
We have a log line for data coming from the server, this mirrors that in an effort to debug opensafely/job-server/issues/335 (and any other maybe-sync issues!).