### PR TITLE
Add Job.status_code to remote format

### DIFF
--- a/jobrunner/sync.py
+++ b/jobrunner/sync.py
@@ -115,6 +115,7 @@ def job_to_remote_format(job):
         "job_request_id": job.job_request_id,
         "action": job.action,
         "status": job.state.value,
+        "status_code": job.status_code.value if job.status_code else "",
         "status_message": job.status_message or "",
         "created_at": job.created_at_isoformat,
         "updated_at": job.updated_at_isoformat,


### PR DESCRIPTION
This adds `status_code` to the payload sent to job-server.

Refs opensafely/job-server#259