### PR TITLE
Timestamp and logging fixes

### DIFF
--- a/jobrunner/create_or_update_jobs.py
+++ b/jobrunner/create_or_update_jobs.py
@@ -192,6 +192,7 @@ def recursively_add_jobs(job_request, project, action, force_run_actions):
         run_command=action_spec.run,
         output_spec=action_spec.outputs,
         created_at=int(time.time()),
+        updated_at=int(time.time()),
     )
     insert(job)
     return job

--- a/jobrunner/service.py
+++ b/jobrunner/service.py
@@ -35,13 +35,19 @@ def main():
 
 def sync_wrapper():
     """Wrap the sync call with logging context and an exception handler."""
+    # avoid busy retries on hard failure
+    sleep_after_error = config.POLL_INTERVAL * 5
     while True:
         try:
             sync.main()
+        except sync.SyncAPIError as e:
+            # Handle these separately as we don't want the full traceback here,
+            # just the text of the error response
+            log.error(e)
+            time.sleep(sleep_after_error)
         except Exception:
             log.exception("Exception in sync thread")
-            # avoid busy retries on hard failure
-            time.sleep(config.POLL_INTERVAL)
+            time.sleep(sleep_after_error)
 
 
 if __name__ == "__main__":

--- a/jobrunner/service.py
+++ b/jobrunner/service.py
@@ -1,14 +1,9 @@
 """
 Script runs both jobrunner flows in a single process.
 """
-import datetime
 import logging
-from pathlib import Path
-import os
-import sys
 import time
 import threading
-
 
 from . import config
 from .log_utils import configure_logging

--- a/jobrunner/sync.py
+++ b/jobrunner/sync.py
@@ -19,6 +19,10 @@ session = requests.Session()
 log = logging.getLogger(__name__)
 
 
+class SyncAPIError(Exception):
+    pass
+
+
 def main():
     log.info(
         f"Polling for JobRequests at: "
@@ -80,7 +84,11 @@ def api_request(method, path, *args, **kwargs):
         )
     )
 
-    response.raise_for_status()
+    try:
+        response.raise_for_status()
+    except Exception as e:
+        raise SyncAPIError(e) from e
+
     return response.json()
 
 

--- a/jobrunner/sync.py
+++ b/jobrunner/sync.py
@@ -51,9 +51,6 @@ def sync():
     jobs_data = [job_to_remote_format(i) for i in jobs]
     log.debug(f"Syncing {len(jobs_data)} jobs back to job-server")
 
-    # log what we're trying to send to job-server
-    log.info(f"Sending jobs to server: {jobs_data}")
-
     api_post("jobs", json=jobs_data)
 
 

--- a/playbooks/TPP.md
+++ b/playbooks/TPP.md
@@ -28,7 +28,20 @@ stderr is in /e/job-runner/service.err.log
 
 These files are rotated by nssm.
 
-TODO: combine these into one log?
+TODO: combine these into one log? (Note stdout is almost always empty)
+
+
+#### Configuring the job-runner
+
+All configuration is via environment variables set in the `.env`
+file.
+
+For instance, to enable DEBUG level logging add the following like to
+the `.env` file:
+
+    LOGLEVEL=DEBUG
+
+And then restart the job-runner.
 
 
 #### Update job-runner


### PR DESCRIPTION
Make sure every job has an `updated_at` timestamp set (which previously it didn't in the short interval between the sync loop creating it and the run loop handling it).

Also tidying up some logging things.